### PR TITLE
Started English translation

### DIFF
--- a/src/guide/editor/adaptation.md
+++ b/src/guide/editor/adaptation.md
@@ -4,67 +4,67 @@ type: guide_editor
 order: 220
 ---
 
-FairyGUI为手游开发提供了自动适应各种设备分辨率的UI适配策略，这意味着开发者只需要制作一套UI，就可以适配所有分辨率的设备。
+FairyGUI provides a UI adaptation strategy that automatically adapts to the resolution of various devices for mobile game development, which means that developers only need to make a set of UIs to adapt to all device resolutions.
 
-## 设计分辨率与设备分辨率
+## Design Resolution and Device Resolution
 
-通常我们会选择一个固定的分辨率进行UI设计和制作，这个分辨率称为设计分辨率。例如1136×640,1280×720都是比较常用的设计分辨率。选定一个设计分辨率后，最大的UI界面（通常就是全屏界面）的大小就限制在这个分辨率。
-运行时设备的分辨率称为设备分辨率，这个分辨率与设计分辨率不一定一致，需要将UI界面经过一定缩放投射到屏幕上。
+Usually we choose a fixed resolution for UI design and production. This resolution is called "design resolution". For example, 1136×640 and 1280×720 are relatively common design resolutions. When a design resolution is selected, the size of the largest UI interface (usually the fullscreen interface) is limited to this resolution.
+The resolution of the device at runtime is called the "device resolution". This resolution isn't necessarily the same as the design resolution. You need to display the UI interface to the screen with a certain scale.
 
-## 全局缩放
+## Global Scale
 
-*（Egret/Laya/Cocos2dx不使用FairyGUI提供的全局缩放，需要使用他们自带的全局缩放策略，请忽略本节内容。参考资料：[Egret](http://developer.egret.com/cn/2d/screenAdaptation/explanation) [LayaAir](https://ldc.layabox.com/doc/?nav=zh-as-1-8-0))*
+*（Egret/Laya/Cocos2dx does not use the global scale provided by FairyGUI，You need to use their own global scaling strategy, please ignore this section. Reference material:[Egret](http://developer.egret.com/cn/2d/screenAdaptation/explanation) [LayaAir](https://ldc.layabox.com/doc/?nav=zh-as-1-8-0)*
 
-当设计分辨率和设备分辨率不一致时，首先进行的是全局缩放。这个全局缩放对UI内部是透明的，也就是说，所有UI界面都不需要理会这个缩放的存在。例如如果整体放大两倍，一个窗口的大小为400×400像素，那么最终显示到屏幕的窗口大小将为800×800像素，但如果你读取这个窗口的width和height，仍然将返回400×400，内部的所有坐标也不会发生变化。
+When the design resolution and device resolution are inconsistent, the first thing to do is global scaling. This global scale is transparent to the inside of the UI, which means that all UI interfaces don't need to worry about the existence of this scale. For example, if the overall size is doubled and the size of a window is 400×400 pixels, the window size that will eventually be displayed to the screen will be 800×800 pixels, but if you read the width and height of this window, it will still return 400×400. All internal coordinates won't change.
 
-设置全局缩放的方式是：
+The way to set global scale is:
 
 ```csharp
     GRoot.inst.SetContentScaleFactor(1136，640，ScreenMatchMode.MatchWidthOrHeight);
 ```
 
-这里1136和640是设计分辨率的宽度和高度。ScreenMatchMode定义了适配模式，可用的常量有：
+Here 1136 and 640 are the width and height of the design resolution. `ScreenMatchMode` defines the adaptation mode. The available constants are:
 
-- `MatchWidthOrHeight` 取宽和高比例较小的进行缩放。例如，设计分辨率是960x640，设备分辨率是1280×720，那么可以得到宽边的比例是1280/960=1.33，高边的比例是720/640=1.125，最后取较小的1.125作为全局缩放系数。这种缩放方式保证内容缩放后始终在屏幕内，可能会留边，但不会超出屏幕看不到。
+- `MatchWidthOrHeight` Scale up and down with a smaller ratio. For example, if the design resolution is 960x640 and the device resolution is 1280×720, then the ratio of the width can be 1280/960=1.33, the ratio of the height is 720/640=1.125, and finally the smaller 1.125 is used as the global zoom. coefficient. This way of scaling ensures that the content is always on the screen after it has been scaled, and it may leave edges, but it won't go beyond the screen.
 
-- `MatchWidth` 固定取宽的比例进行缩放。高边可能会超出屏幕。
+- `MatchWidth` Scale using a fixed width. The height may exceed the screen.
 
-- `MatchHeight` 固定取高的比例进行缩放。宽边可能会超出屏幕。
+- `MatchHeight` Scale using a fixed height. The width may exceed the screen.
 
-在Unity版本里，除了使用API设置全局缩放外，还提供了一个Unity组件：UIContentScaler。在启动场景里任何一个GameObject挂上UIContentScaler组件即可。并不需要每个场景都挂。参考[这里](#../unity/index.html#UIContentScaler)。
+In the Unity version, in addition to using the API to set global scaling, a Unity component is also provided: `UIContentScaler`. Just hang the `UIContentScaler` component on any `GameObject` in the startup scene. You don't need to hang every scene. Refer to [here](#../unity/index.html#UIContentScaler).
 
-## 逻辑屏幕
+## Logical Screen Size
 
-全局缩放后的屏幕大小就是逻辑屏幕大小，在上例中，设备分辨率是1280×720，全局缩放系数是1.125，那么逻辑屏幕大小就是（1280/1.125=1138, 720/1.125=640）= 1138x640。GRoot这个UI根组件的大小始终占满逻辑屏幕，也就是说，逻辑屏幕的大小可以通过GRoot.inst.width和GRoot.inst.height获得。
+The screen size after global scaling is the "logical screen size". In the above example, the device resolution is 1280×720, and the global scaling factor is 1.125, then the logical screen size is (1280/1.125=1138, 720/1.125=640)= 1138x640 . The size of the `GRoot` UI root component always fills the "logical screen". The size of the logical screen can be obtained by `GRoot.inst.width` and `GRoot.inst.height`.
 
-## 全屏界面适配
+## Fullscreen Interface Adaptation
 
-全局缩放后，大部分UI都不需要做任何调整，只有一个例外，就是设计为全屏的界面。在上例中，在设计分辨率下，全屏界面的大小是960x640，我们也是按这个大小设计全屏组件的。全局缩放后，这时逻辑屏幕的大小变成1138x640了，那大小就不一致了。这时我们需要重新调整组件大小使之满屏。
+After global scaling, most UIs don't need to be adjusted. With one exception, they are designed to be full-screen. In the above example, at the design resolution, the size of the full-screen interface is 960x640, and we also design full-screen components by this size. After global scaling, the size of the logical screen becomes 1138x640, and the size is inconsistent. At this point we need to resize the component to make it full.
 
-如果你使用的是UIPanel，那么在Inspector上设置Fit Screen为Fit Size就可以了；如果是动态创建的UI，那么可以使用API：
+If you're using `UIPanel`, then setting the `Fit Screen` to `Fit Size` on the Inspector is fine; if it's a dynamically created UI, you can use the API:
 
 ```csharp
-    //设置组件全屏，即大小和逻辑屏幕大小一致。
-    //组件的内部应该做好关联处理， 以应对大小改变。
+    // Set the component to fullscreen, that is, the size and logical screen size are the same.
+    // The inside of the component should be handled in association with the size change.
     aComponent.SetSize(GRoot.inst.width, GRoot.inst.height);
-    //或者更简洁的方式
-    aComponnet.MakeFullScreen();
+    // Or, a more concise way
+    aComponent.MakeFullScreen();
 ```
 
-一般来说，手游在进入游戏后，屏幕大小就不会变化的。但如果你开发的是桌面游戏，又或者支持横竖屏切换的游戏，即屏幕大小是会变化的，那么全屏界面还需要加上对屏幕大小的约束，即
+一In general, the screen size won't change after the mobile game starts. But if you're developing a desktop game, or a game that supports horizontal and vertical screen switching (the screen size will change), then the fullscreen interface needs to add a constraint on the screen size, ie.:
 
 ```csharp
    aComponent.AddRelation(GRoot.inst, RelationType.Size);
 ```
 
-当然，这仅仅是处理全屏界面的一种方式。在有的情况下，例如如果选用“MatchHeight”模式，也就是高度优先的适配方法，这种方法保证了UI界面垂直方向的内容总是铺满，而水平方向就有可能超出屏幕。这种适配方式需要设计师有“安全区域”的设计思维，不能安排内容在超出屏幕的部分。例如，将全屏界面居中，牺牲掉两边的内容：
+Of course, this is just one way to handle a fullscreen interface. In some cases, for example, if you select the `MatchHeight` mode, which is a high-priority adaptation method, this method ensures that the vertical direction of the UI interface is always full, and the horizontal direction may exceed the screen. This kind of adaptation requires the designer to have a "safe area" design and to think in those terms (like not being able to arrange content beyond the screen). For example, center the fullscreen interface and sacrifice the content on both sides:
 
 ```csharp
     aComponent.x = (GRoot.inst.width – aComponent.width)/2;
 ```
 
-这样，左边缘和右边缘将会被屏幕边缘裁剪掉，这要求设计师在设计时就考虑到这种情况。
+In this way, the left and right edges will be cropped off by the edge of the screen, which requires the designer to take this into account when designing.
 
-## 自动调整UI布局
+## Automatically Adjust UI Layout
 
-全屏组件在适配过程中需要重新设置全屏，那么组件大小就会发生变化，这时需要使用关联系统让组件内的元素自动布局在正确的位置。实例可以参考[关联系统](relation.html#实例解析)。
+The full-screen component needs to be reset to fullscreen during the adaptation process, and the component size will change. In this case, the associated system needs to be used to automatically lay out the elements in the component in the correct position. Examples can be referred to at [association system](relation.html#instanceresolution).

--- a/src/guide/editor/button.md
+++ b/src/guide/editor/button.md
@@ -4,185 +4,187 @@ type: guide_editor
 order: 130
 ---
 
-按钮是FairyGUI里最常用的扩展组件。他用于多个用途，例如传统UI框架中的RadioButton、Checkbox、List Item等，在FairyGUI里通通都是按钮。
+Buttons are the most commonly used extensions in FairyGUI. It's used for many purposes, such as `RadioButton`, `Checkbox`, `ListItem`, etc. in the traditional UI framework, all in the FairyGUI are buttons.
 
-## 创建按钮
+## Create Button
 
-可以通过两种方式创建按钮组件。
+There are two ways to create a button component.
 
-- 点击主菜单“资源”->“新建按钮”，按照向导的提示一步步完成。
+- Click on `Main Menu -> "Resources" -> "New Button"` and follow the wizard's prompts to complete step by step.
 
 ![](../../images/20170803143326.png)
 
-- 新建一个组件，然后在组件属性里选择扩展为“按钮”。然后创建一个控制器，点击“按钮模板”，选择一个按钮模板。
+- Create a new component and select `Expand as "Button"` in the component properties. Then create a controller, click on `"Button Template"` and select a button template.
 
-## 设计属性
+## Design Attribute
 
-在组件编辑状态下，按钮组件的属性面板是：
+In the component editing state, the properties panel of the button component is:
 
 ![](../../images/20170803143647.png)
 
-- `模式` 有三种按钮模式选择。
- - `普通按钮` 用于点击->响应的用途，无状态。
- - `单选按钮` 有一个是否选中的状态。被点击后处于选中状态，再点击仍然保持选中状态。如果要实现单选按钮组，那可以将多个单选按钮的“连接”属性绑定到同一个控制器，具体请参考[控制器](controller.html#和按钮的联动)。
- - `复选按钮` 有一个是否选中的状态。被点击后处于选中状态，再点击则变成不选中状态。
+- `Mode` There are three button mode selections.
+ - `Common` is used for click->response purposes, no state.
+ - `Radio` has a status of whether it's selected. After being clicked, it's selected, and then click to keep it selected. If you want to implement a radio button group, you can bind the "Connect" property of multiple radio buttons to the same controller. For details, please refer to [Controller](controller.html#和按钮的联动).
+ - `Check` has a status of whether it's selected. After being clicked, it's selected, and then clicked to become unchecked.
 
-- `声音` 设置按钮被点击时的音效。如果所有按钮都共用一种音效，不需要每个按钮设置，在项目属性对话框里有一个全局的设置。
+- `Sound` Sets the sound effect when the button is clicked. If all buttons share a single sound effect, you don't need each button setting, there is a global setting in the project properties dialog.
 
-- `音量` 设置按钮点击音效的播放音量。0-100。
+- `Volume` Sets the playback volume of the sound effect that's played when the button is clicked. 0-100.
 
-- `按下效果` 用控制器可以随意控制按钮在不同页面的形态，但出于方便，内置了几种常用的按钮按下效果。
- - `缩放` 按下时按钮变大或变小。按下缩放是通过改变按钮组件的ScaleX和ScaleY实现的。注意：设置了按下缩放后，按钮初始化时会自动将轴心设置为（0.5，0.5）。*(除了Unity平台，其他平台可能会有设置了按下变小，当正好按在按钮边缘时会出现有按下效果，但不触发点击事件的问题。解决方案是使用按下变大而不是按下变小。如果一定要按下变小，建议阀值不要太大，稍微有效果就可以，)*
- - `变暗` 按下时按钮呈现变暗的状态。变暗实际是通过改变按钮组件内所有图片的颜色实现的。**如果你还有对按钮内图片的颜色的单独设置，这可能会发生冲突，导致颜色设置丢失。***（因为Egret和Laya平台不支持图片变色，所以变暗也不可用。其实在手机上，用缩放效果更合适。）*
+- `Down Effect` With the controller, you can control the shape of the buttons on different pages at will, but for convenience, several commonly used button press effects are built-in.
+ - `Scale` The button becomes larger or smaller when pressed. Pressing the zoom is done by changing the ScaleX and ScaleY of the button component. Note: When the zoom is set, the axis will be automatically set to (0.5, 0.5) when the button is initialized. * (In addition to the Unity platform, other platforms may have a setting that is smaller and smaller, when pressed just at the edge of the button, there is a pressing effect, but the click event isn't triggered. The solution is to use the press to become bigger instead of Press to make it smaller. If it must be pressed down, it's recommended that the threshold shouldn't be too large, it will be slightly effective,)*
+ - `Dark` The button is darkened when pressed. Darkening is actually done by changing the color of all the pictures in the button component. **If you have separate settings for the color of the image inside the button, this can be a conflict, resulting in a loss of color settings.***(Because the Egret and Laya platforms do not support image discoloration, darkening isn't available. In fact, on mobile phones, it's more appropriate to use the zoom effect.)*
 
-**命名约定**
+**Naming Convention**
 
-- `button` 按钮控制器必须命名为“button”，如果你不需要按钮有特殊效果，那么这个控制器不是必须的。
+- `button` The button controller must be named "button". If you don't need a special effect on the button, then this controller isn't required.
 
-按钮控制器各个页面的说明：
+Description of each page of the button controller:
 
-`up` 按钮正常的状态；
-`down` 普通按钮按下时的状态/单选或多选按钮被选中时的状态；
-`over` 当鼠标指针悬浮在按钮上方时的状态；
-`selectedOver` 当单选或多选按钮选中时，鼠标指针悬浮到按钮上方时的状态；
-`disabled` 按钮不可用时的状态；
-`selectedDisabled` 当单选或多选按钮选中时，按钮不可用时的状态。
+`up` The button's default state;
+`down` The state when the normal button is pressed/the status of the single or multi-select button is selected;
+`over` The state when the mouse pointer is hovering over the button;
+`selectedOver` When the single or multi-select button is selected, the state when the mouse pointer is hovered over the button;
+`disabled` The state when the button isn't available;
+`selectedDisabled` The state when the button isn't available when the single or multiple selection button is selected.
 
-通常我们设计一个4态按钮，用up/down/over/selectedOver就可以了，如果是用在移动设备上，那么使用up/down就可以了。当按钮不可用时，FairyGUI提供了一个默认的变灰的效果，如果你不想要这个效果，那就要用到disabled和selectedDisabled进行设计。
+Usually we design a 4-state button, `up`/`down`/`over`/`selectedOver`. If designed solely for mobile devices, then `up`/`down` is fine. When the button isn't available, FairyGUI provides a default grayed out effect. If you don't want this effect, use `disabled` and `selectedDisabled` to design.
 
-- `title` 可以是普通文本，富文本，也可以是标签、按钮。
+- `title` It can be plain text, `RichText`, `Label`s, or `Button`s.
 
-- `icon` 可以是装载器，也可以是标签、按钮。
+- `icon` It can be a `Loader`, `Label`, or `Button`.
 
-注意：按钮组件内并非只能有“title”和“icon”，你可以放置任何元件，例如放置任意多的文本、装载器等。“title”和“icon”的设定只是用于按钮组件在编辑器实例化时能够直观设置而已。
+Note: There are not only "title" and "icon" in the button component. You can place any component, such as placing as many texts, loaders, and so on. The settings for "title" and "icon" are only used to intuitively set the button component when the editor is instantiated.
 
-## 实例属性
+## Instance Attribute
 
-在舞台上选中一个按钮组件，右边的属性面板列表出现：
+Select a button component on the Stage and the list of property panels on the right appears:
 
 ![](../../images/20170803150509.png)
 
-- `状态` 单选按钮或多选按钮可以设置按钮是否处于选中状态。
+- `Status` A radio button or a multi-select button sets whether the button is selected.
 
-- `标题` 设置的文本将赋值到标签组件内的“title”元件的文本属性。如果不存在“title”元件，则什么事都不会发生。
-  这里的输入框比较小，如果要输入大文本，则可以在输入激活时，按CTRL+ENTER，然后会弹出一个专门用于输入文本的窗口。
+- `Title` The set text will be assigned to the text attribute of the "title" component within the label component. If the "title" component doesn't exist, nothing will happen.
+   The input box here is relatively small. If you want to enter large text, you can press `CTRL+ENTER` when the input is activated, and then a window will pop up for inputting text.
 
-- `选中时标题` 当按钮处于选中状态时，设置标题属性为这里设置的值；当按钮处于不选中状态时，恢复原标题属性的值。
+- `Selected Title` When the button is selected, the title property is set to the value set here; when the button is unchecked, the value of the original title property is restored.
 
-- `标题颜色` 默认的标题颜色是标签组件内的“title”元件的文字颜色，勾选后，可以修改文字颜色。如果不存在“title”元件，则什么事都不会发生。
+- `Color` The default title color is the text color of the "title" component in the label component. When checked, the text color can be modified. If the "title" component doesn't exist, nothing will happen.
 
-- `字体大小` 默认的字体大小是标签组件内的“title”元件的字体大小，勾选后，可以修改字体大小。如果不存在“title”元件，则什么事都不会发生。
+- `Font Size` The default font size is the font size of the "title" component in the label component. When checked, the font size can be modified. If the "title" component doesn't exist, nothing will happen.
 
-- `图标` 设置的URL将赋值到标签组件内的“icon”元件的图标属性。如果不存在“icon”元件，则什么事都不会发生。
+- `Icon` The set URL will be assigned to the icon property of the "icon" component within the `Label` component. If the "icon" component doesn't exist, nothing will happen.
 
-- `选中时图标` 当按钮处于选中状态时，设置图标属性为这里设置的值；当按钮处于不选中状态时，恢复原图标属性的值。
+- `Selected Icon` When the button is selected, the icon property is set to the value set here; when the button is unchecked, the value of the original icon property is restored.
 
-- `点击声音` 勾选后可以重新设置按钮的点击音效，覆盖按钮在设计期的设置。
+- `Sound` After checking, you can reset the button click sound and override the button's setting during the design period.
 
-- `音量` 设置按钮点击音效的播放音量。0-100。
+- `Volume` Sets the playback volume of the sound effect that's played when the button is clicked. 0-100.
 
-- `连接` 控制器可以与按钮联动。请参阅[控制器](controller.html#和按钮的联动)
+- `Connect` The controller can be linked to the button. Please refer to [Controller](controller.html#和按钮的联动)
 
 ## GButton
 
-设置按钮的标题或者图标，你甚至不需要强制对象为GButton的类型，直接用GObject提供的接口就可以，例如：
+Set the title or icon of the button. You don't even need to force the object to be of type `GButton`. You can use the interface provided by `GObject` directly, for example:
 
 ```csharp
     GObject obj = gcom.GetChild("n1");
     obj.text = "hello";
-    obj.icon = "ui://包名/图片名";   
+    obj.icon = "ui://PackageName/ImageName";
 ```
 
-如果是单选或者多选按钮，下面的方法设置是否选中：
+If it's a single or multiple selection button, the following method settings are selected:
 
 ```csharp
     GButton button = gcom.GetChild("n1").asButton;
     button.selected = true;
 ```
 
-通常对于单选/多选按钮，用户点击后就能切换状态。如果你不需要这样，希望只能通过API改变状态，那么可以：
+Usually for the radio/multiple selection button, the user can switch states after clicking. If you don't need this, and you want to change the state only through the API, you can:
 
 ```csharp
-    //关闭后你只能通过改变selected属性修改按钮状态，用户点击不会改变状态。
+    // After closing, you can only change the state of the button by changing the selected property. The user clicks it without changing the state.
     button.changeStateOnClick = false;
 ```
 
-通过代码设置按钮与控制器的联动的方式是：
+The way to link the controller to the controller via the code setting button is:
 
 ```csharp
     button.pageOption.controller = aController;
-    button.pageOption.index = 1; //通过索引设置
-    button.pageOption.name = "page_name"; //或通过页面名称设置
+    button.pageOption.index = 1; //Set by index
+    button.pageOption.name = "page_name"; //Or set by page name
 ```
 
-按钮全局声音的设置为：
+Setting the global button sound:
 
 ```csharp
-    //Unity版本要求一个AudioClip对象，如果是使用库里面的资源，那么可以使用：
-    UIConfig.buttonSound = (AudioClip)UIPackage.GetItemAssetByURL("ui://包名/声音名");
+    // The Unity version requires an AudioClip object. If you are using the resources in the library, you can use:
+    UIConfig.buttonSound = (AudioClip)UIPackage.GetItemAssetByURL("ui://PackageName/SoundName");
 
-    //其他版本要求一个资源url，即：
-    UIConfig.buttonSound = "ui://包名/声音名";
+    // Other versions require a resource url, namely:
+    UIConfig.buttonSound = "ui://PackageName/SoundName";
 
-    //全局音量    
+    // Global volume
     UIConfig.buttonSoundVolumeScale = 1f;
 ```
 
-这个设置只能在创建任何UI前设置。如果要控制全局声音的开关或音量，可以这样：
+If you want to control the global sound toggle or volume, you can do like this:
+*(This setting can only be set before any UI is created)*
 
 ```csharp
-    //开关声音(Laya和Egret自己有提供声音开关，不需要用这个，请查阅他们的文档）
+    // Switching sounds (Laya and Egret have their own sound switches, do not need to use this, please consult their documentation)
     GRoot.inst.EnabledSound();
     GRoot.inst.DisableSound();
 
-    //调整全局声音音量，这个包括按钮声音和动效播放的声音
+    // Adjust the global sound volume, this includes the sound of the button sound and the sound of the animation
     GRoot.inst.soundVolume = 0.5f;
 ```
 
-监听普通按钮点击的方式为：（注意，点击事件不只是按钮有，任何支持触摸的元件都有，例如普通组件、装载器、图形等，他们的点击事件注册方式和按钮是相同的。）
+The way to listen to normal button clicks is:
+*(Note that click events are not just buttons. On any touch-enabled components, such as normal components, loaders, graphics, etc., their click event registration method and button are the same.)*
 
 ```csharp
-    //Unity/Cry
+    // Unity/Cry
     button.onClick.Add(onClick);
 
-    //AS3
+    // AS3
     button.addClickListener(onClick);
 
-    //Egret
+    // Egret
     button.addClickListener(this.onClick, this);
 
-    //Laya
+    // Laya
     button.onClick(this, this.onClick);
 
-    //Cocos2dx
+    // Cocos2dx
     button->addClickListener(CC_CALLBACK_1(AClass::onClick, this));
 ```
 
-按钮可以模拟触发点击：
+A button simulating a trigger click:
 
 ```csharp
-    //模拟触发点击，只会有一个触发的表现，以及改变按钮状态，不会触发侦听按钮的点击事件。
+    // Simulating a triggered click will only have one triggered performance, as well as changing the button state, without triggering a click event on the listen button.
     button.FireClick(true);
 
-    //如果同时要触发点击事件，需要额外调用：(仅Unity/Cry示例，其他平台自己研究）
+    // If you want to trigger a click event at the same time, you need to make additional calls: (Unity/Cry example only, other platforms study it yourself)
     button.onClick.Call();
 ```
 
-单选和多选按钮状态改变时有通知事件：
+There are notification events when the radio and multi-select button states change:
 
 ```csharp
-    //Unity/Cry
+    // Unity/Cry
     button.onChanged.Add(onChanged);
 
-    //AS3
+    // AS3
     button.addEventListener(StateChangeEvent.CHANGED, onChanged);
 
-    //Egret
+    // Egret
     button.addEventListener(StateChangeEvent.CHANGED, this.onChanged, this);
 
-    //Laya
+    // Laya
     button.on(fairygui.Events.STATE_CHANGED, this, this.onChanged);
 
-    //Cocos2dx
+    // Cocos2dx
     button->addEventListener(UIEventType::Changed, CC_CALLBACK_1(AClass::onChanged, this));
 ```

--- a/src/guide/editor/combobox.md
+++ b/src/guide/editor/combobox.md
@@ -4,129 +4,129 @@ type: guide_editor
 order: 140
 ---
 
-## 创建下拉框
+## Create ComboBox
 
-可以通过两种方式创建下拉框组件。
+There are two ways to create a`ComboBox`component.
 
-- 点击主菜单“资源”->“新建下拉框”，然后按照向导的提示一步步完成。
+- Click on the main menu "Resources" -> "New ComboBox" and follow the wizard's prompts to complete step by step.
 
 ![](../../images/20170803191137.png)
 
-- 新建一个组件，然后在组件属性里选择扩展为“下拉框”。
+- Create a new component and select Expand as "ComboBox" in the component properties.
 
-## 设计属性
+## Design Properties
 
-在组件编辑状态下，下拉框组件的属性面板是：
+In the component editing state, the properties panel of the `ComboBox` component is:
 
 ![](../../images/20170803161919.png)
 
-- `弹出组件` 下拉框在选项弹出时需要用到的组件。
+- `Popup Component` The`ComboBox`is required for the option to pop up.
 
 ![](../../images/20170803162921.png)
 
-这个组件最基本的设计就是一个背景+一个列表。背景对容器组件做好宽高关联。列表需要命名为“list”，并设置好“项目资源”，一般来说，列表的“溢出处理”都设置为“垂直滚动”。列表不需要建立任何关联。
+The most basic design of this component is a background + a list. The background makes a wide and high correlation to the container components. The list needs to be named "list" and set the "Project Resource". In general, the "overflow processing" of the list is set to "vertical scrolling". The list doesn't need any set `Relation`s.
 
-当下拉框需要弹出下拉列表时，会将弹出组件的宽度设置成下拉框的宽度，然后填充列表数据，并按照“可见项目数量”的要求调整列表高度，最后显示出来。
+When the `ComboBox` needs to pop up the drop-down list, the width of the pop-up component will be set to the width of the `ComboBox`, then the list data will be filled, and the height of the list will be adjusted according to the requirements of the number of visible items, and finally displayed.
 
-**命名约定**
+**Naming Convention**
 
-- `button` 下拉框也需要一个按钮控制器，因为他和按钮的形态是一样的。可以按设计按钮的方式设计下拉框。当下拉框被点击下拉时，“button”控制器将停留在“down”页，下拉列表收回后，“button”控制器回到“up”页或“over”页。
-- 
-- `title` 可以是普通文本，富文本，也可以是标签、按钮。
+- `button` The `ComboBox` also requires a button controller because it's the same shape as the button. The `ComboBox` can be designed in the same way as the design button. When the `ComboBox` is clicked down, the "button" controller will stay on the "down" page. After the drop-down list is retracted, the "button" controller will return to the "up" page or the "over" page.
 
-- `icon` 可以是装载器，也可以是标签、按钮。
-- 
-## 实例属性
+- `title` It can be plain text, rich text, labels, or buttons.
 
-在舞台上选中一个下拉框组件，右边的属性面板列表出现：
+- `icon` It can be a loader, label, or button.
+
+## Instance Attributes
+
+Select a `ComboBox` component on the Stage and the list of property panels on the right appears:
 
 ![](../../images/20170803163612.png)
 
-- `标题` 设置的文本将赋值到标签组件内的“title”元件的文本属性。如果不存在“title”元件，则什么事都不会发生。
+- `Title` The set text will be assigned to the text attribute of the "title" component within the label component. If the "title" component doesn't exist, nothing will happen.
 
-- `图标` 设置的URL将赋值到标签组件内的“icon”元件的图标属性。如果不存在“icon”元件，则什么事都不会发生。
+- `Icon` The set URL will be assigned to the icon property of the "icon" component within the `Label` component. If the "icon" component doesn't exist, nothing will happen.
 
-- `可见项目数量` 下拉显示时最多显示的项目数量。例如，如果这里设置的值为10，而下拉框的数据有100条，那么下拉列表的视口会调整到只显示10条，其他需要滚动查看。
+- `View Count` The maximum number of items displayed when the drop-down is displayed. For example, if the value set here is 10, and the data in the`ComboBox`has 100, then the viewport of the drop-down list will be adjusted to display only 10, and the others need to scroll.
 
-- `弹出方向` 下拉列表的弹出方向。
+- `Popup` The pop-up direction of the drop-down list.
 
-- `选择控制` 可以绑定一个控制器。这样当下拉框选择发生改变时，控制器也同时跳转到相同索引的页面。反之亦然，如果控制器跳转到某个页面，那么下拉框也同时选定相同索引的项目。
+- `Selection Control` You can bind a controller. Thus, when the`ComboBox`selection changes, the controller also jumps to the same index page. Vice versa, if the controller jumps to a page, the`ComboBox`also selects the same indexed item.
 
-- `编辑列表项目` 点击后弹出对话框，可以编辑下拉列表的项目：
+- `Edit Items` After clicking, a dialog box pops up to edit the items in the drop-down list.:
 
 ![](../../images/20170803173655.png)
 
-- `文本` 设置这个列表项目的标题。
+- `Text` Set the title of this list item.
 
-- `图标` 设置这个列表项目的图标。
+- `Icon` Sets the icon for this list item.
 
-- `值` 设置这个列表项目的value属性。用途可参考下面API的说明。
+- `Value` Sets the value attribute of this list item. For the purpose, please refer to the description of the API below.
 
 ## GComboBox
 
-我们可以在编辑器编辑下拉列表的项目，也可以用代码动态设置，例如：
+We can edit the drop-down list of items in the editor or dynamically with code, for example:
 
 ```csharp
     GComboBox combo = gcom.GetChild("n1").asComboBox;
 
-    //items是列表项目标题的数组。
+    // Items is an array of list item titles.
     combo.items = new string[] { "Item 1", "Item 2", ...};
 
-    //values是可选的，代表每个列表项目的value。
+    // Values are optional and represent the value of each list item.
     combo.values = new string[] { "value1", "value2", ...};
 
-    //获得当前选中项的索引
+    // Get the index of the currently selected item
     Debug.Log(combo.selectedIndex);
 
-    //获得当前选中项的value。
+    // Get the value of the currently selected item.
     Debug.Log(combo.value);
 
-    //设置选中项，通过索引
+    // Set the selected item to pass the index
     combo.selectedIndex = 1;
 
-    //设置选中项，通过value
+    // Set the selected item, passing a value
     combo.value = "value1";
 ```
 
-下拉框选择改变时有通知事件：
+There's a notification event when the`ComboBox` selection changes:
 
 ```csharp
-    //Unity/Cry
+    // Unity/Cry
     combo.onChanged.Add(onChanged);
 
-    //AS3
+    // AS3
     combo.addEventListener(StateChangeEvent.CHANGED, onChanged);
 
-    //Egret
+    // Egret
     combo.addEventListener(fairygui.StateChangeEvent.CHANGED, this.onChanged, this);
 
-    //Laya
+    // Laya
     combo.on(fairygui.Events.STATE_CHANGED, this, this.onChanged);
 
-    //Cocos2dx
+    // Cocos2dx
     combo->addEventListener(UIEventType::Changed, CC_CALLBACK_1(AClass::onChanged, this));
 ```
 
-点击空白处后弹出框会自动关闭，如果要获得这个关闭的通知，可以监听移出舞台的事件，例如：
+After clicking in a blank space, the popup will automatically close. If you want to get this notification upon closing, you can listen to events based on exiting the Stage. For example:
 
 ```csharp
-    //Unity/Cry
+    // Unity/Cry
     combo.dropdown.onRemoveFromStage.Add(onPopupClosed);
 
-    //AS3
+    // AS3
     combo.dropdown.addEventListener(Event.REMOVED_FROM_STAGE, onPopupClosed);
 
-    //Egret
+    // Egret
     combo.dropdown.addEventListener(egret.Event.REMOVED_FROM_STAGE, this.onPopupClosed, this);
 
-    //Laya
+    // Laya
     combo.dropdown.on(laya.events.Event.UNDISPLAY, this, this.onPopupClosed);
 
-    //Cocos2dx
+    // Cocos2dx
     combo->getDropdown()->addEventListener(UIEventType::Exit, CC_CALLBACK_1(AClass::onPopupClosed, this));
 ```
 
-如果要手工关闭弹出框：
+If you want to close the popup manually:
 
 ```csharp
     GRoot.inst.HidePopup();

--- a/src/guide/editor/component.md
+++ b/src/guide/editor/component.md
@@ -4,128 +4,134 @@ type: guide_editor
 order: 90
 ---
 
-组件是FairyGUI中的一个基础容器。组件可以包含一个或多个基础显示对象，也可以包含组件。
+`Component` is a base container in FairyGUI. A `Component` can contain one or more base display objects, as well as components.
 
-## 组件属性
+## Component Attributes
 
-在舞台上点击**空白处**，右边属性栏显示的是容器组件的属性：
+Click on the **blank** on the Stage, and the property bar on the right shows the properties of the container-component:
 
 ![](../../images/20170802091705.png)
 
-- `宽` `高` 设置组件的宽度和高度。
+- `Width` `Height` Set the width and height of the component.
 
-- `宽度限制` `高度限制` 左边为最小值，右边为最大值，0表示不限制。注意：修改宽高限制不会修改当前的宽高，即使当前的宽高值不符合限制。
+- `Width Limit` `Height Limit` The left side is the minimum value, the right side is the maximum value, and 0 means no limit. Note: Modifying the width and height limits doesn't modify the current width and height, even if the current width and height values don't meet the limit.
 
-- `轴心` 旋转、缩放、倾斜这些变换时的轴心点。取值范围是0~1。例如X=0.5，Y=0.5表示中心位置。点击右边的小三角形可以快速设置一些常用的值，比如中心，左下角，右下角等。
+- `轴心` Rotate, scale, and tilt the pivot points of these transformations. The value ranges from 0 to 1. For example, X = 0.5 and Y = 0.5 indicate the center position. Click on the small triangle on the right to quickly set some commonly used values, such as center, bottom left corner, bottom right corner, and so on.
 
-- `同时作为锚点` 勾选这个选项后，元件的原点位置将设置为轴心所在的位置。默认情况下，每个元件的(0,0)都是在左上角；勾选了轴心同时作为锚点后，则元件的(0,0)在轴心的位置。注意，关联系统是不计入这个选项的影响的，所以勾选了锚点后的元件，再使用宽高类的关联，可能表现不正常。
+- `同时作为锚点` When this option is checked, the component's origin position will be set to the position of the axis. By default, each component's (0,0) is in the upper left corner; when the axis is selected as the anchor point, the component's (0,0) is at the axis position. Note that the associated system doesn't count towards the impact of this option, so check the components behind the anchor point, and then use the association of the wide and high class, may not behave normally.
 
-- `初始名字` 当组件被实例化（限编辑器内）时，自动设置组件的名称为这里设置的值。最常见的用途就是，FairyGUI里要求窗口框架组件需命名为frame，那么你创作了一个窗口框架组件后，设置“初始名字”为frame，以后每次拖入这个组件，自动就取好名字了，不用每次修改。
+- `初始名字` When the component is instantiated (within the editor), the name of the component is automatically set to the value set here. The most common use is that the FairyGUI requires the window frame component to be named frame. Then after you create a window frame component, set the "initial name" to the frame. After each dragging into the component, you will automatically get the name. You don't have to change it every time.
 
 - `点击穿透` 默认情况下，组件的矩形区域（宽x高）将拦截点击，勾选后，点击事件可以穿透组件中**没有内容**的区域。详细说明在[点击穿透](#点击穿透)。
 
-- `溢出处理` 表示处理超出组件矩形区域的内容的方式。注意：**溢出处理**不支持在代码里动态修改。
+- `溢出处理` 表示处理超出组件矩形区域的内容的方式。注意:**溢出处理**不支持在代码里动态修改。
  - `可见` 表示超出组件矩形区域的内容保持可见，这是默认行为。
  - `隐藏` 表示超出组件矩形区域的内容不可见，相当于对组件应用了一个矩形遮罩。
  - `垂直滚动` `水平滚动` `自由滚动` 与其他UI框架很大不同，在FairyGUI中不需要拖入滚动控件实现滚动。任何一个普通的组件，只需要简单设置一个属性就可以使组件具有滚动功能。溢出处理中有三种滚动的选择，自由滚动就是横向和纵向都能滚动。详细说明在[滚动容器](scrollpane.html)。
 
-- `边缘` 设定组件四周的留空。一般用在“溢出处理”为“隐藏”或者“滚动”的情况。边缘虚化目前只有在Unity平台支持。如果组件发生了对内容的剪裁，则可以在边缘产生虚化的效果，增强用户体验。这个值应该比较大才能看出效果，例如50。
+- `边缘` Set the space around the component to be left blank. It is generally used when "overflow processing" is "hidden" or "scrolling". Edge blur is currently only supported on the Unity platform. If the component has been tailored to the content, it can create a blur effect on the edge to enhance the user experience. This value should be large to see the effect, such as 50.
 
 <center>
 ![](../../images/20170802095820.png)
 </center>
 
-- `自定义遮罩` 详细说明在[遮罩](#遮罩)。
+- `Custom Mask` Details are in [Mask](#Mask).
 
-- `反向（挖洞）` 详细说明在[遮罩](#遮罩)。
+- `Reverse (Burrowing)` Details are in [Mask](#Mask).
 
-- `像素点击测试` 详细说明在[点击测试](#点击测试)。
+- `Pixel Hit Test` Detailed description in [Click Test](#ClickTest).
 
-- `扩展` 详细说明在[扩展](#扩展)。
+- `Extension` Detailed description in [Extension](#Extension).
 
-- `背景颜色` 设置组件编辑区域的背景颜色，仅用于辅助设计，实际组件背景都是透明的，不会有颜色。如果你需要组件有一个真实的背景色，可以放置一个图形。
+- `Background Color` Set the background color of the component editing area, only for auxiliary design. The actual component background is transparent, there will be no color. If you need components with a real background color, you can place a graphic.
 
-- `自定义数据` 可以设置一个自定义的数据，这个数据FairyGUI不做解析，按原样发布到最后的描述文件中。开发者可以在运行时获取。获取方式根据SDK版本有所不同，如果是支持XML包格式的SDK，获取方式为：
+- `Custom Data` You can set custom data. FairyGUI doesn't parse it, and it's released to the final description file as-is. Developers can retrieve it at runtime. The acquisition method varies according to the SDK version. If the SDK supports the XML package format, the acquisition method is:
   ```csharp
-    //Unity/Cry
+    // Unity/Cry
     aComponent.packageItem.componentData.GetAttribute("customData");
-    //Cocos2dx/Vision
+
+    // Cocos2dx/Vision
     aComponent->getPackageItem()->componentData->RootElement()->Attribute("customData");
-    //LayaAir
+
+    // LayaAir
     aComponent.packageItem.componentData.getAttribute("customData");
-    //Egret
+
+    // Egret
     aComponent.packageItem.componentData.attributes.customData;
-    //AS3/Starling
+
+    // AS3/Starling
     aComponent.packageItem.componentData.@customData;
   ```
-  如果是支持二进制包格式的SDK，获取方式为：
+  If the SDK supports the binary package format, the acquisition method is:
     ```csharp
-    //Unity/Cry/Laya/Egret
+    // Unity/Cry/Laya/Egret
     aComponent.baseUserData;
-    //Cocos2dx/Vision
+
+    // Cocos2dx/Vision
     aComponent->getBaseUserData();
   ```
 
-## 设计图功能
+## Design Function
 
 ![](../../images/20170802102647.png)
 
-可以设定一个组件的设计图。设计图将显示在舞台上，可以设置显示在组件内容的底层或者上层。使用设计图可以使拼接UI更加快速和精准。
+You can set the design of a component. The design will be displayed on the Stage and can be set to appear at the bottom or top of the component content. Using a design diagram can make the stitching UI faster and more accurate.
 
-设计图不会发布到最终的资源中。
+The design map won't be published to the final resource.
 
-## 点击穿透
+## Click Through
 
-组件内，显示在前面的元件将优先收到点击事件。如果该元件是可触摸的，则点击事件结束，不会继续向后传递。
+Within the component, the component shown in the front will receive the click event first. If the component is touchable, the click event ends and won't continue to be passed backwards.
 
-在组件宽度x高度的范围内点击测试都是有效的（无法穿透），无论这个范围内是否有子元件。举个例子说明。
+Clicking on the test within the component's area is valid (no clicks uncaptured), regardless of whether there are subcomponents in this range. Let's look at an example.
 
-这是组件A，大小为400x400，内容为4个白色的矩形：
+This is component `A`, which is 400x400 in size and has 4 white rectangles.:
 
 ![](../../images/2015-12-21_164631.png)
 
-这是组件B，大小为400x400，内容为一个红色的矩形：
+This is component `B`, which is 400x400 in size and has a red rectangle:
 
 ![](../../images/2015-12-21_164656.png)
 
-将B先添加进舞台，然后再添加A到舞台，也就是说，A显示在B的前面，效果如下图：
+Add `B` to the Stage first, then add `A` to the stage. That is, `A` is displayed in front of `B`. The effect is as follows:
 
 ![](../../images/2015-12-21_165100.png)
 
-可以看到，虽然A在B的上面，但红色方块是可见的，因为A在此区域并没有内容。当点击图中绿色点的位置时，点击事件将在A上面触发，而B是点击不了的。这是因为在A的范围内，点击是不能穿透的。
+We can see that although `A` is above `B`, the red square is visible because `A` has no content in this area. When you click on the position of the green dot in the graph, the click event will trigger on `A`, and `B` won't click. This is because within the scope of `A`, the click isn't ignored.
 
-如果希望A能被穿透应该怎样？组件属性里提供设置：![](../../images/20170802103448.png)，勾选即可。代码里也可以设置：
+What if I want `A` to be ignored? The settings are provided in the component properties:![](../../images/20170802103448.png)，and can also be set in code:
 
 ```csharp
-    //true表示不可穿透，false表示可穿透。
+    // True means clickable (captured) and false means ignored (uncaptured).
     aComponent.opaque = false;
 ```
 
-设置穿透后，只有点击4个白块时，A才接收到点击事件，如果点击绿色点位置，B将接收到点击事件。**这个特性在设计一些全屏界面时尤其要注意。例如一个主界面添加到舞台，并设置为全屏，如果不穿透的话，那么Stage.isTouchOnUI将一直返回true。**
+After disabling its click-capturing, `A` only receives the click event when clicking 4 white blocks. If the green dot position is clicked, `B` will receive the click event.
+**This feature is especially important when designing some fullscreen interfaces. For example, a main interface is added to the Stage and set to full screen. If the click isn't ignored, then `Stage.isTouchOnUI` will always return true.**
 
-**注意：图片和普通文字是不接受点击的，如果一个只含有图片或普通文字的组件，设置了点击穿透，那么整个组件就是完全穿透了，不会拦截到任何点击。**
+**Note: Pictures and normal text don't accept clicks. If a component that only contains images or plain text is set to clickable, then the entire component is completely ignored and no clicks are captured.**
 
-## 像素点击测试
+## Pixel Hit Test
 
-有些特殊需求，需要用到不规则区域的点击测试。首先你要准备一张包含不规则区域的图片，图片里不透明的像素代表接受点击的区域，透明的像素代表点击穿透的区域，组件里超出图片范围的也是可穿透的区域。
+For some special needs, you need to use `Pixel Hit Test` on an irregular area. First you need to prepare a picture with irregular areas. The opaque pixels in the picture represent the areas that accept the click, the transparent pixels represent the areas where clicks are ignored, and the areas in the component that are beyond the scope of the image are also ignored areas.
 
-把这张图片拖入舞台，然后在组件的“像素点击测试”属性里，选择这张图片。
+Drag this image onto the Stage and select it in the component's `Pixel Hit Test` property.
 
 <center>
 ![](../../images/20170925151838.png)
 </center>
 
-## 遮罩
+## Mask
 
-FairyGUI的遮罩有两种：矩形遮罩和自定义遮罩。
+There are two types of masks for FairyGUI: rectangular masks and custom masks.
 
-### 矩形遮罩
+### Rectangular Mask
 
-将组件的“溢出处理”设置为“隐藏”或者“滚动”，那么组件就带了矩形遮罩。超出组件(矩形区域-边缘留空）的区域都不可见。无论在什么平台，这种遮罩的效率是最高的。
+Set the component's `Overflow Processing` to `Hidden` or `Scroll`, and the component has a rectangular mask. Areas that are out of the component (rectangular area - edge left) aren't visible. This mask is the most efficient no matter what platform it's on.
 
-### 自定义遮罩
+### Custom Mask
 
-可以设置组件内一个图片或者图形作为组件的遮罩。这种遮罩一般都是使用模板测试(Stencil Op)技术。各个平台支持的力度不同：
+You can set a picture or graphic inside the component as a mask for the component. Such masks are generally using Stencil Op technology. The strengths supported by each platform are different:
 
 - `AS3/Starling/Egret` 使用图形（Graph）作为遮罩时，有图形的区域内容**可见**，例如，一个圆形，则圆形区域内可见，其他区域不可见。
 
@@ -143,11 +149,12 @@ FairyGUI的遮罩有两种：矩形遮罩和自定义遮罩。
 
   使用图片（Image）作为遮罩时，图片内透明度为0的像素对应区域的内容**不可见**，反之可见。超出图片区域的内容**不可见**。
 
-Unity版本须知：如果你要对使用了自定义遮罩的组件进行设置倾斜、设置BlendMode，设置滤镜，又或者曲面UI中含有自定义遮罩的组件时，需要额外的设置才能显示正常。请参考[PaintMode](../unity/special.html#PaintMode)
+Note on the Unity version: If you want to set the tilt of a component that uses a custom mask, set `BlendMode`, set a filter, or a component with a custom mask in the surface UI, additional settings are required to display properly. Please refer to [PaintMode](../unity/special.html#PaintMode)
 
-### 反向遮罩（挖洞）
+### Reverse Mask (Burrow)
 
-效果和正常遮罩相反，也就是可见的区域变不可见，不可见的区域变可见*(仅部分引擎支持，例如Unity、Laya）*。例如：
+The effect is the opposite of a normal mask, ie the visible area becomes invisible and the invisible area becomes visible
+*(Only some of the engines support this, such as Unity, Laya)*. E.g:
 
 ![](../../images/20170622162422.png)
 
@@ -155,42 +162,42 @@ Unity版本须知：如果你要对使用了自定义遮罩的组件进行设置
 
 使用图片（Image）作为遮罩时，图片内透明度为0的像素对应区域的内容**可见**，反之不可见。超出图片区域的内容**可见**。
 
-注意：
-1. 当遮罩发生时，点击测试也同样会发生变化，只有显示出来的内容才接受点击检测，被遮住的内容不接受点击检测。
-2. 对于正在编辑的组件，遮罩只有在预览时才能看到效果。
-3. 定义了遮罩的组件，其内部的元件永远无法和外部的元件合并Draw Call，因为他们有不同的材质属性。
+Note:
+1. When the mask occurs, the click test will also change. Only the displayed content will accept the click detection, and the hidden content will not accept the click detection.
+2. For components that are being edited, the mask will only see the effect when previewed.
+3. The component that defines the mask, its internal components can never be combined with external components' draw calls because they have different material properties.
 
-## 扩展
+## Extensions
 
 ![](../../images/20170802154335.png)
 
-可以看到有六种“扩展”选择。组件可以随意在这些“扩展”中切换。选择哪种“扩展”，组件就有了那种扩展的属性和行为特性。
+You can see that there are six "extended" options. Components can switch between these "extensions" at will. Which "extension" is chosen, the component has the extended attributes and behavioral characteristics.
 
-下面以按钮为例，介绍一下“扩展”是怎样工作的。选择“扩展”为按钮后，可以看到属性面板下方出现了按钮相关的提示和设置。
+Let's take a button as an example to show how "extension" works. After selecting "Extend" as the button, you can see the prompts and settings related to the button below the property panel.
 
 ![](../../images/20170802154543.png)
 
-这里先忽略按钮组件的设置，后续教程会详细说明。从提示可以看到，FairyGUI中“扩展”的定义方式是以”名称约定“为基础的。一个按钮，可以带有标题和图标，这个标题（一般是一个文本）和图标（一般是一个装载器）需要你自己放置到组件中，并把他们名字设置为title和icon，就像这样：
+Ignore the settings of the button component first, as detailed in the following tutorial. As you can see from the prompts, the definition of "extension" in FairyGUI is based on the "naming convention". A button with a title and an icon, the title (usually a text) and the icon (usually a loader) need to be placed into the component yourself and set their name to title and icon, like this:
 
 ![](../../images/2016-01-11_183043.jpg)
 
-然后我们测试一下这个刚制作好的组件。把按钮组件拖到另一个组件中，并设置一下“标题”和“图标”，如下图
+Then we test the newly created component. Drag the button component to another component and set the "title" and "icon" as shown below:
 
 ![](../../images/20170802155233.png)
 
-效果出来了。这说明标题文本被自动设置到了名称为“title”的文本元件上，图标被自动设置到了名称为“icon”的装载器元件上。
+The effect is coming out. This means that the title text is automatically set to the text component named "title" and the icon is automatically set to the loader component named "icon".
 
-如果按钮组件里没有放置名称为icon的装载器控件呢？那么设置图标就没有效果，仅此而已。其他约定的处理方式也相同。不会有任何报错。
+What if the loader control named icon isn't placed in the button component? Then setting the icon has no effect, nothing more. Other conventions are handled in the same way. There will be no errors.
 
-从按钮的设计就可以看出FairyGUI“扩展”功能的优势所在。如果一个编辑器提供了现成的按钮组件，无论设计者考虑多么周到，都无法覆盖所有需求，就一个按钮，随便想到的变化就可能有：是否带图标/图标在左边还是右边/图标与文字的距离/是否带文字/文字的颜色/文字的大小等等。而在FairyGUI里，按钮组件内所有东西都是任由你布置的。
+From the button design you can see the advantages of the FairyGUI "extension" feature. If an editor provides off-the-shelf button components, no matter how thoughtful the designer is, it can't cover all the requirements. Just a button, the changes that come to mind may be: whether the icon/icon is on the left or the right/icon and text Distance/whether with text/text color/text size, etc. In FairyGUI, everything in the button component is left to you.
 
-“扩展”还赋予了组件行为，具体到按钮上，就是处理各种鼠标或触摸事件，按下时改变状态（单选/多选），单击时播放声音等等。这些都是由“扩展”的底层去处理的。这部分同样是通过“名称约定”来工作的。例如，按钮内只要提供了名称为“button”的控制器，当鼠标悬浮在按钮上方时，就会自动切换该控制器到“over”页面；当鼠标按下时，就会自动切换该控制器到“down”页面，等等。如果按钮没有提供名称为“button”的控制器呢？上述行为就不会发生。按钮控制器并不是必须的，如果你不需要以上行为，就不用提供。
+"Extension" also gives the component behavior, specifically to the button, is to handle a variety of mouse or touch events, change the state when pressed (single / multiple selection), play sound when clicked, and so on. These are all handled by the underlying "extensions". This part also works through the "name convention". For example, if a controller with the name "button" is provided in the button, when the mouse is hovered over the button, the controller will be automatically switched to the "over" page; when the mouse is pressed, the controller will be automatically switched. Go to the "down" page, and so on. What if the button doesn't provide a controller with the name "button"? The above behavior will not happen. The button controller isn't required, if you don't need the above behavior, you don't have to provide it.
 
-其他类型的“扩展”的工作方式与按钮类似。后续文档会详细介绍每种“扩展”的属性和行为。
+Other types of "extensions" work in a similar way to buttons. Subsequent documentation details the properties and behavior of each "extension".
 
 ## GComponent
 
-组件支持动态创建，例如：
+Components support dynamic creation, for example:
 
 ```csharp
     GComponent gcom = new GComponent();
@@ -198,72 +205,73 @@ Unity版本须知：如果你要对使用了自定义遮罩的组件进行设置
     GRoot.inst.AddChild(gcom);
 ```
 
-动态创建的组件是空组件，可以作为其他组件的容器。一个常见的用途，如果你要建立一个多层的UI管理系统，那么空组件就是一个合适的层级容器选择。动态创建的组件默认是点击穿透的，也就是说如果直接new一个空组件作为接收点击用途，你还得这样设置：
+Dynamically created components are empty components that can serve as containers for other components. A common use, if you want to build a multi-layer UI management system, then the empty component is a suitable hierarchical container selection. The dynamically created component is click-through by default, which means that if you directly add a new empty component as a receiving click, you have to set it like this:
 
 ```csharp
-    //设置组件点击不穿透。
+    // Set the component to capture the click.
     gcom.opaque = true;
 ```
 
-如果要创建UI库里的组件，应该使用这样的方式：
+If you want to create a component in the UI library, you should use this method:
 
 ```csharp
-    GComponent gcom = UIPackage.CreateObject("包名","组件名").asCom;
+    GComponent gcom = UIPackage.CreateObject("PackageName","ComponentName").asCom;
     GRoot.inst.AddChild(gcom);
 ```
-FairyGUI和Flash/Cocos类似，采用树状的结构组织显示对象。容器可以包含一个或多个基础显示对象，也可以包含容器。这个树状结构称为显示列表。FairyGUI提供了API管理显示列表。
 
-### 显示列表管理
+Similar to Flash/Cocos, FairyGUI organizes display objects in a tree structure. A container can contain one or more base display objects or a container. This tree structure is called a display list. FairyGUI provides a list of API management displays.
 
-- `numChildren` 获得容器内孩子元件的数量。
+### Display List Management
 
-- `AddChild` `AddChildAt` 向容器内添加元件。前者将元件添加到显示列表的队尾；后者可以指定一个索引控制元件的插入位置。
+- `numChildren` Get the number of child components in the container.
 
-- `RemoveChild` `RemoveChildAt` `RemoveChildren` 从容器内删除元件。当元件从显示对象中移出时，将不再占用显示资源。但元件从显示列表移出后，只是不显示，并没有销毁，如果你没有保存这个对象的引用留待后续使用，或者没有调用对象的Dispose方法销毁对象，那么会产生内存泄露。
+- `AddChild` `AddChildAt` Add components to the container. The former adds components to the end of the display list; the latter can specify the insertion position of an index control element.
 
-- `GetChild` `GetChildAt` 通过索引或名称获得元件引用。元件的名字是允许重复的，在这种情况下，GetChild返回第一个匹配名称的对象。
+- `RemoveChild` `RemoveChildAt` `RemoveChildren` Remove components from the container. When a component is removed from the display object, it no longer occupies display resources. However, after the component is removed from the display list, it isn't displayed and isn't destroyed. If you don't save the reference to the object for later use, or if you don't call the object's `Dispose` method to destroy the object, a memory leak will occur.
 
-- `GetChildIndex` 获得指定元件在显示列表中的索引。
+- `GetChild` `GetChildAt` Get a component reference by index or name. The name of the component is allowed to repeat, in which case `GetChild` returns the first object that matches the name.
 
-- `SetChildIndex` `SwapChildren` `SwapChildrenAt` 设置元件在显示列表中的索引。
+- `GetChildIndex` Gets the index of the specified component in the display list.
 
-### 渲染顺序
+- `SetChildIndex` `SwapChildren` `SwapChildrenAt` Sets the index of the component in the display list.
 
-在FairyGUI中，显示列表是以树形组织的，下面说的渲染顺序均指在**同一个父元件**下安排的顺序，不同父元件的元件是不可能互相交错的，这是前提，请注意。
+### Rendering Order
 
-显示对象的渲染顺序取决于它的显示列表中的顺序，顺序大的后渲染，即显示在较前面。一般来说，我们都是使用AddChild或SetChildIndex调整渲染顺序。例如如果要一个元件显示在容器的最前面，那调用AddChild(元件)就可以了，AddChild是可以重复调用的。也可以调用SetChildIndex设置对象在显示列表中的具体位置，例如SetChildIndex(元件,0)就可以将元件置于最底层。
+In FairyGUI, the display list is organized in a tree. Please note: the rendering order below refers to the order arranged under the **same parent component**. It's impossible to interlace the components of different parents.
 
-还有另外一个因子可以影响渲染循序，它就是GObject.sortingOrder。**这个属性只用于特定的用途，不作常规的使用。它一般用于类似固定置顶的功能，另外，永远不要将sortingOrder用在列表中。**sortingOrder越大，则渲染顺序越后，即显示到更前面的位置。一般情况下，sortingOrder为0，这时渲染顺序由显示对象在显示列表中的顺序决定。sortingOrder可以令你更灵活的控制渲染循序。例如，如果希望一个元件始终保持在其他元件上方，可以设置其sortingOrder一个较大的整数值，这样无论容器使用AddChild添加了多少元件，这个元件依然显示在最前面。（sortingOrder的效率较差，勿做频繁调用的用途）
+The rendering order of the display object depends on the order in its display list, and the large sequential rendering is displayed in front. In general, we use `AddChild` or `SetChildIndex` to adjust the rendering order. For example, if you want a component to appear at the top of the container, then call `AddChild(component)`, `AddChild` can be called repeatedly. You can also call `SetChildIndex` to set the specific position of the object in the display list, such as `SetChildIndex(component, 0)` to put the component at the bottom.
 
-上面提到的都是调整对象在显示列表中的顺序，如果不想调整这个顺序的同时，又要调整渲染顺序，组件还提供了另一种方式。
+There's another factor that can affect the rendering order, which is `GObject.sortingOrder`. **This property is for specific purposes only and isn't used routinely. It's generally used for functions like fixed topping. Also, never use sortingOrder in the list.** The larger the `sortingOrder`, the later the rendering order is, and the more advanced position is displayed. In general, the `sortingOrder` is 0, and the rendering order is determined by the order in which the display objects are displayed in the list. `SortingOrder` gives you more control over the rendering sequence. For example, if you want a component to always remain above other components, you can set its `sortingOrder` to a larger integer value so that the component still appears first, no matter how many components the container adds with `AddChild`. (`SortingOrder` is inefficient, don't use it frequently)
+
+All of the aforementioned are the object-sort order in the display list. If you don't want to adjust the order (and adjust the rendering order), the component provides another way:
 
 ```csharp
-    //升序，这是默认值，按照对象在显示列表中的顺序，从小到大依次渲染，效果就是序号大的显示在较前面。
+    // Ascending order (this is the default value), according to the order of the objects in the display list, from small to large rendering. The effect is that the serial number is displayed in the front.
     aComponent.childrenRenderOrder = ChildrenRenderOrder.Ascent;
 
-    //降序，按照对象在显示列表中的顺序，从大到小依次渲染，效果就是序号小的显示在较前面。
+    // Descending, according to the order of the objects in the display list, from the largest to the smallest. The effect is that the serial number is displayed in the front.
     aComponent.childrenRenderOrder = ChildrenRenderOrder.Descent;
 
-    //拱形，需要指定一个顶峰的索引，从两端向这个索引位置依次渲染，效果就是这个位置的对象显示在最前面，两边的对象依次显示在后面。
+    // Arch, you need to specify an index of the peak, from the two ends to the index position in turn, the effect is that the object at this position is displayed in the front, the objects on both sides are displayed in the back.
     aComponent.childrenRenderOrder = ChildrenRenderOrder.Arch;
-    aComponent.apexIndex = 3; //索引为3的对象显示在最前面。
+    aComponent.apexIndex = 3; // An object with an index of 3 is displayed first.
 ```
 
-### 绑定扩展类
+### Binding Extension Class
 
-可以绑定一个类为组件的扩展类。首先，编写一个扩展类：
+You can bind an extension class whose class is a component. First, write an extension class:
 
 ```csharp
     public class MyComponent : GComponent
     {
         GObject msgObj;
 
-        //如果你有需要访问容器内容的初始化工作，必须在这个方法里，而不是在构造函数里。各个SDK的函数原型的参数可能略有差别，请以代码提示为准。
+        // If you have initialization work that needs to access the contents of the container, you must do it in this method, not in the constructor. The parameters of the function prototype of each SDK may be slightly different. Please follow the code hints.
         override protected void ConstructFromXML(XML xml)
         {
             base.ConstructFromXML(xml);
-            
-            //在这里继续你的初始化
+
+            // Continue your initialization here
             msgObj = GetChild("msg");
         }
 
@@ -274,17 +282,17 @@ FairyGUI和Flash/Cocos类似，采用树状的结构组织显示对象。容器�
     }
 ```
 
-然后注册你的扩展类。注意，**必须在组件构建前注册**，如果你使用的是UIPanel，那么在Start里注册是不够早的，必须在Awake里，总之，如果注册不成功，90%可能都是注册晚于创建，10%可能是URL错误，这可以通过打印URL排查。
+Then register your extension class. Note that **it must be registered before the component is built**. If you are using `UIPanel`, it isn't early enough to register in `Start`. It must be in `Awake`. In short, if the registration is unsuccessful, 90% may be registered later than Created, 10% may be a URL error, which can be checked by printing the URL.
 
 ```csharp
-    UIObjectFactory.SetPackageItemExtension("ui://包名/组件A”, typeof(MyComponent));
+    UIObjectFactory.SetPackageItemExtension("ui://PackageName/ComponentA", typeof(MyComponent));
 ```
 
-这样就为组件A绑定了一个实现类MyComponent 。以后所有组件A创建出来的对象（包括在编辑器里使用的组件A）都是MyComponent类型。然后我们就可以为MyComponent添加API，用更加面向对象的方式操作组件A。例如：
+This binds component `A` with an implementation class, `MyComponent`. All objects created by component `A` in the future (including component `A` used in the editor) are of type `MyComponent`. Then we can add an API to `MyComponent` and manipulate component `A` in a more object-oriented way. E.g:
 
 ```csharp
-    MyComponent gcom = (MyComponent)UIPackage.CreateObject(“包名“， ”组件A”);
+    MyComponent gcom = (MyComponent)UIPackage.CreateObject("PackageName"， "ComponentA");
     gcom.ShowMessage("Hello world");
 ```
 
-注意：如果组件A只是一个普通的组件，没有定义“扩展”，那么基类是GComponent，如上例所示；如果组件A的扩展是按钮，那么MyComponent的基类应该为GButton，如果扩展是进度条，那么基类应该为GProgressBar，等等。这个千万不能弄错，否则会出现报错。
+Note: If component `A` is just a normal component, there's no definition of "extension", then the base class is `GComponent`, as shown in the above example; if the extension of component `A` is a button, then the base class of `MyComponent` should be `GButton`, if the extension is a progress bar , then the base class should be `GProgressBar`, and so on. This must not be mistaken, otherwise there will be an error.

--- a/src/guide/editor/group.md
+++ b/src/guide/editor/group.md
@@ -4,68 +4,68 @@ type: guide_editor
 order: 80
 ---
 
-在舞台上选定一个或多个元件，然后按Ctrl+G，就可以建立一个组。 FairyGUI的组有两种类型，`普通组`和`高级组`。
+Select one or more components on the Stage and press `Ctrl+G` to create a group. There are two types of FairyGUI groups, `Normal Group` and `Advanced Group`.
 
-## 普通组
+## Normal Group
 
-普通组仅在编辑时有效，是辅助你进行UI设计的。普通组发布后不存在，也就是在运行时无法访问到普通组。
+The normal group is only effective when editing, it's to assist you in UI design. The normal group does not exist after it's released, that is, it can't access the normal group at runtime.
 
-普通组的作用有：
-1. 可以整体一起移动；
-2. 可以整体一起调整深度；
-3. 可以整体复制和粘贴。
-4. 双击组，进入组内部后，可以随意调整各个元件的深度，不影响组外的东西。
-5. 当组大小改变时，组内的内容将同时增大或者缩小。
+The role of the general group is:
+1. Can move together as a whole;
+2. The depth can be adjusted together as a whole;
+3. Can be copied and pasted as a whole.
+4. Double-click the group to enter the inside of the group. You can adjust the depth of each component at will, without affecting anything outside the group.
+5. When the group size changes, the contents of the group will increase or decrease at the same time.
 
-普通组的属性面板：
+The properties panel of the normal group:
 
 ![](../../images/20170726152337.png)
 
-- `名称` 可以给普通组取名，用途也仅仅是辅助设计。
+- `Name` can give the name of the ordinary group, and the purpose is only the auxiliary design.
 
-## 高级组
+## Advanced Group
 
-高级组除了具有普通组所有的功能外，它在发布后仍然保留，也就是在运行时可以通过代码访问高级组对象。所以它可以像一个普通元件那样设置关联和属性控制。
+In addition to having all the functions of a normal group, the advanced group remains after it's released, that is, it can access advanced group objects through code at runtime. So it can set `Relation`s and property controls like a normal `Component`.
 
-高级组的作用有：
-1. 可以设置可见性。如果组不可见，则组内的所有元件均不可见。
-2. 设置属性控制。高级组支持的属性控制有：显示控制，位置控制，大小控制。
-3. 设置关联。
-4. 设置布局。
+The role of the advanced group is:
+1. You can set visibility. If the group isn't visible, all components within the group aren't visible.
+2. Set the property control. The attribute controls supported by the advanced group are: display control, position control, and size control.
+3. Set the `Relation`.
+4. Set the Layout.
 
-例如有一批元件，你希望在某一页隐藏，那么你可以对每个元件设置一次显示控制，你也可以将他们建立一个高级组，然后对高级组设置一个显示控制，后者是不是简洁很多？
+For example, if there are a batch of components that you want to hide on a certain page, then you can set a display control for each component. You can also set them up to a high-level group and then set a display control for the advanced group. The latter isn't very simple.
 
-高级组的属性面板：
+The properties panel of the advanced group:
 
 ![](../../images/20170726153357.png)
 
-高级组具有简单的布局功能。目前支持`水平布局`和`垂直布局`。
+Advanced groups have a simple layout feature. Currently supports `Horizontal Layout` and `Vertical Layout`.
 
-- `水平布局`
+- `Horizontal Layout`
 
-组内的元件按照他们在容器中的显示顺序水平依次排列，他们之间的间隔由列距指定。当组的宽度改变时，每个元件都**按比例增大**，然后重新排列，列距保持不变。当组内的元件自身的宽度改变时，组自动按规则重新排列。
+The components within the group are arranged horizontally in the order in which they appear in the container, and the spacing between them is specified by the column spacing. As the width of the group changes, each component **is scaled up**, then rearranged, and the column spacing remains the same. When the width of the components themselves within the group changes, the groups are automatically rearranged according to the rules.
 
-- `垂直布局`
+- `Vertical Layout`
 
-组件的元件按照他们在容器中的显示顺序垂直依次排列，他们之间的间隔由行距指定。当组的高度改变时，每个元件都**按比例增大**，然后重新排列，行距保持不变。当组内的元件自身的高度改变时，组自动按规则重新排列。
+The same as `Horizontal Layout`, except using height instead of width.
 
-以下用例子说明一下有布局和无布局的区别：
+The following examples illustrate the difference between with a layout and without a layout:
 
-这是一个无布局的组，可以看到，组大小改变时，里面的方块大小同时改变，但位置不变。
+This is a non-layout `Group`. As you can see, when the group size changes, the size of the square inside changes at the same time, but the position does not change.
 
 ![](../../images/gaollg17.gif)
 
-这是一个水平布局的组，可以与上图比较一下差别。
+This is a horizontal layout `Group` that can be compared to the above picture.
 
 ![](../../images/gaollg18.gif)
 
-如果组内有设置了大小限制的元件，那么组大小改变时，这些元件的大小限制依然生效，在以下的例子中，由于左右两个色块被限制了大小，所以组变大时，只有中间的色块改变大小。
+If there are components with size limits set in the `Group`, the size limit of these components will still take effect when the group size changes. In the following example, since the left and right color blocks are limited in size, when the group becomes large, only the middle The color patches change size.
 
 ![](../../images/gaollg19.gif)
 
 ## GGroup
 
-高级组可以在运行时通过代码访问。但要注意的是，组不是容器，它并没有维护一个组内元件的列表。如果你需要遍历组内的所有元件，你需要遍历容器组件的所有孩子，测试他们group属性。代码如下：
+Advanced `Group`s can be accessed through code at runtime. **But note that the `Group` isn't a container, it does not maintain a list of components within a group**. If you need to iterate through all the components in the group, you need to iterate through all the children of the container component and test their group properties. Code show as below:
 
 ```csharp
     GGroup aGroup = gcom.GetChild("groupName").asGroup;
@@ -77,4 +77,5 @@ order: 80
     }
 ```
 
-**必须注意，对于没有布局的高级组，运行时是不会自动改变大小的，也就是无论组内的元素怎么变动，这种高级组的大小是不会自动改变的！** 如果确实需要改变，那么只能自行调用GGroup.EnsureBoundsCorrect。
+**It must be noted that for advanced groups without layout, the runtime does not automatically change the size. That is, regardless of how the elements in the group change, the size of this advanced group does not change automatically!**
+If you truly need to change it, you can simply call `GGroup.EnsureBoundsCorrect` yourself.

--- a/src/guide/editor/index.md
+++ b/src/guide/editor/index.md
@@ -4,469 +4,473 @@ type: guide_editor
 order: 0
 ---
 
-## 打开项目和创建项目
+## Open Project and Create Project
 
-启动FairyGUI编辑器后，首先显示的是打开项目/创建项目的窗口：
+After launching the FairyGUI editor, the first window to open the project/create project is displayed:
 
 ![](../../images/2017-04-25_230248.png)
 
-- `历史记录` 曾经打开过的项目可以直接从列表中点击打开。
-- `删除` 点击右上的垃圾桶按钮删除选定的打开历史记录。
-- `打开其他` 通过选择一个项目描述文件 xxx.fairy 打开一个已有项目。
-- `打开目录` 通过选择项目所在的目录打开一个已有项目。适用于打开2.x版本的项目。
+- `History` Items that have been opened can be opened directly from the list.
+- `Delete` Click the trash can button on the top right to delete the selected open history.
+- `Open Other` Open an existing project by selecting a project description file xxx.fairy.
+- `Open Directory` Open an existing project by selecting the directory where the project is located. Applicable to open the 2.x version of the project.
 
-编辑器支持同时打开多个项目。Windows平台下，可以直接启动多个FairyGUI编辑器。Mac平台下，你可以在打开一个项目后，再点击菜单“文件”->“在新窗口打开项目”打开其他项目。
+The editor supports opening multiple projects at the same time. On the Windows platform, multiple FairyGUI editors can be launched directly. On the Mac platform, you can open other projects after opening a project and then clicking `Main Menu -> "File" -> "Open project in new window"`.
 
 ![](../../images/2017-04-25_230303.png)
 
-在指定位置创建一个新的UI项目。
+Create a new UI project at the specified location.
 
-- `项目名称` 任意的项目名称。
-- `项目类型` UI项目类型，即目标平台。不同的平台类型在资源组织、发布上有一定的差别。不需要担心这里选择错了项目类型，在项目创建后可以随时调整UI项目类型，操作位置在菜单“文件”->“项目属性”里。
+- `Project name` Any item name.
+- `Project Type` UI item type, which is the target platform. Different platform types have certain differences in resource organization and distribution. **You don't need to worry about choosing the wrong project type here. You can adjust the UI project type at any time after the project is created**. The operation location is in `Main Menu -> "File" -> "Project Properties"`.
 
-## 资源管理
+## Resource Management
 
-FairyGUI的项目在文件系统的结构为：
+The structure of the FairyGUI project in the file system is:
 
 ![](../../images/2017-04-07_112222.png)
 
-- FairyGUI是以包为单位组织资源的。包在文件系统中体现为一个目录。assets目录下每个目录都是一个包。包内的每个资源都有一个是否导出的属性，一个包只能使用其他包设置为已导出的资源，而不设置为导出的资源是不可访问的。同时，只有设置为导出的组件才可以使用代码动态创建。
+- FairyGUI organizes resources on a per-package basis. The package is embodied as a directory in the file system. Each directory in the assets directory is a package. Each resource in the package has an attribute that is exported. A package can only be set to an exported resource using another package, and the resource that isn't set to be exported is inaccessible. At the same time, only components that are set to be exported can be dynamically created using code.
 
-- 包发布后可以得到一个描述文件和一张或多张纹理集（不同平台的文件数量和打包方式可能有差别）。FairyGUI是不处理包之间的依赖关系的，如果B包导出了一个元件B1，而A包的A1元件使用了元件B1，那么在创建A1之前，必须保证B包已经被载入，否则A1里的B1不能正确显示（但不会影响程序正常运行）。这个载入需要由开发者手动调用，FairyGUI不会自动载入。
+- After the package is released, you can get a description file and one or more texture sets (the number of files and packaging methods may vary from platform to platform). FairyGUI doesn't handle the dependencies between packages. If the B package exports a component B1 and the A1 component of the A package uses component B1, then before creating A1, the B package must be loaded, otherwise A1 B1 doesn't display correctly (but doesn't affect the normal operation of the program). This loading needs to be manually called by the developer, and FairyGUI will not load automatically.
 
-- 如何划分包，有一个原则，就是不要建立交叉的引用关系。例如避免A包使用B包的资源，B包使用C包的资源这类情况。我们一般都建立一个或多个公共包，把整个项目需要频繁使用到的资源放在这里，把一些基础组件，例如按钮、滚动条、窗口背景等也放到这里。其他包需要使用时直接从公共包拖入就可以了。除了公共包，其他包相互之间尽量不发生引用关系。简洁的依赖关系可以使程序员更轻松地控制UI资源的载入和卸载。
+- How to divide packages. There's a principle - don't establish cross-reference relationships. For example, avoid the case where the `A` package uses the `B` package's resources, and the `B` package uses the `C` package's resources. We generally create one or more public packages, put the resources that need to be used frequently throughout the project, and put some basic components, such as buttons, scrollbars, window backgrounds, etc. here. Other packages need to be dragged directly from the public package when they need to be used. In addition to public packages, other packages don't have a reference relationship with each other. Simple dependencies make it easier for programmers to control the loading and unloading of UI resources.
 
-- 包划分的粒度一般没有一个硬性的规定。在具体实践中，有不同的方案，比如有的人喜欢分的比较细，一个模块一个包；有的人喜欢包少一点，就把不同UI模块的资源和组件都堆在一起。这些方案对UI的运行性能影响都不大。但是图片资源尽量不要太分散，因为不同包的图片是不能打在同一张纹理集上的，如果资源太分散，可能造成纹理集的留空过多，浪费空间。
+- The granularity of package partitioning generally doesn't have a hard rule. In practice, there are different solutions. For example, some people prefer to be more detailed, one module and one package; some people prefer to pack less resources and components of different UI modules. These scenarios have little impact on the performance of the UI. However, the **image resources shouldn't be too scattered, because the images of different packages cannot be on the same texture set**. If the resources are too scattered, the texture set may be left too much and waste space.
 
-**增删改资源**
+**Add, Delete, and Change Resources**
 
-你可以直接在文件管理器（或Finder）进行这些操作：
+You can do this directly in the file manager (or Finder):
 
-- `增加资源` 可以直接将素材放置到包目录里。也可以将另外项目的包直接拷入到assets目录。然后点击库面板上面的刷新按钮。
+- `Add resources` You can place the material directly into the package directory. You can also copy the package of another project directly into the assets directory. Then click the refresh button above the library panel.
 
-- `移动资源` 可以将素材在包内各个文件夹里移动。但不能跨包移动，否则引用关系将丢失。然后点击库面板上面的刷新按钮。
+- `Mobile Resources` You can move the material in various folders within the package. But it can't be moved across packages, otherwise the reference relationship will be lost. Then click the refresh button above the library panel.
 
-- `删除资源` 可以直接在包目录里删除素材；然后点击库面板上面的刷新按钮。
+- `Delete resource` You can delete the material directly in the package directory; then click the refresh button above the library panel.
 
-- `替换资源` 可以用外部工具打开素材编辑，也可以直接替换文件。这类操作无需刷新，返回到编辑器就可以看到最新修改的结果。
+- `Replace resource` You can open the material edit with an external tool, or you can directly replace the file. This type of operation doesn't need to be refreshed, and you can see the results of the latest changes when you return to the editor.
 
 **package.xml**
 
-每个包里都有一个package.xml文件，这个是包的数据库文件，如果这个文件被破坏，那么包的内容将无法读取。在多人协作的情况下，如果package.xml出现冲突，请谨慎处理。
+Each package has a `package.xml` file, which is the package's database file. If the file is destroyed, the contents of the package won't be readable. In the case of multiplayer collaboration, if there's a conflict in `package.xml`, please handle it carefully.
 
-## 库面板
+## Library Panel
 
-进入编辑器后，主界面的左边是库面板。库面板包括资源库和收藏夹两个子面板。
+After entering the editor, the left side of the main interface is the library panel. The library panel includes two sub-panels, the repository and the favorites.
 
 ![](../../images/2017-04-25_231318.png)
 
-库面板里采用树状结构显示。顶层节点是包，每个包下面可以创建文件夹。可以直接在键盘上按包名第一个字符的拼音的首字母，直接定位包。
+The library panel is displayed in a tree structure. The top-level nodes are packages, and folders can be created under each package. You can directly locate the package by directly typing the first letter of the first character of the package name on the keyboard.
 
-可以直接将图片、声音、动画、文字等素材从文件管理器（或Finder）中拖动到资源库中。素材可以随意移动，也可以使用复制和粘贴功能。如果要更新素材，可以点击资源，在右键菜单中选择“更新资源”，也可以在文件管理器（或Finder）中直接替换文件，后者适合批量操作。
+You can drag images, sounds, animations, text, and so on directly from the file manager (or Finder) into the repository. The material can be moved at will, or you can use the copy and paste function. If you want to update the material, you can click on the resource, select "Update Resource" in the right-click menu, or you can directly replace the file in the file manager (or Finder), which is suitable for batch operations.
 
-**资源URL地址**
+**Resource URL Address**
 
-在FairyGUI中，每一个资源都有一个URL地址。选中一个资源，右键菜单，选择“复制URL”，就可以得到资源的URL地址。无论在编辑器中还是在代码里，都可以通过这个URL引用资源。例如设置一个按钮的图标，你可以直接从库中拖入，也可以手工粘贴这个URL地址。这个URL是一串编码，并不可读，在开发中使用会造成阅读困难，所以我们通常使用另外一种格式：ui://包名/资源名。两种URL格式是通用的，一种不可读，但不受包或资源重命名的影响；另一种则可读性较高。
+In FairyGUI, each resource has a URL. Select a resource, right-click menu, select "Copy URL", you can get the URL address of the resource. Resources can be referenced through this URL, both in the editor and in the code. For example, to set a button icon, you can drag directly from the library, or you can manually paste the URL address. This URL is a bunch of encodings that aren't readable. It can be difficult to read in development, so we usually use another format: ui://package/resource name. The two URL formats are generic, one unreadable, but not affected by package or resource renaming; the other is more readable.
 
-**资源导出**
+**Resource Export**
 
-包内的每个资源都有一个是否导出的属性，已导出的资源的图标右下角有一个小红点。使用右键菜单提供的功能可以方便的切换一个或多个资源的导出属性。
+Each resource in the package has an attribute that is exported. The icon of the exported resource has a small red dot in the lower right corner. Use the functions provided in the right-click menu to easily switch the export properties of one or more resources.
 
-**收藏夹**
+**Favorites**
 
-收藏夹提供了一个快速访问常用组件的功能。可以将一些常用的组件或素材放置在收藏夹里，便于快速访问。也可以实现一个类似控件面板的功能。在资源库里右键单击一个或多个资源，然后在右键菜单中选择“加入收藏夹”，就可以将资源加入收藏夹。
+Favorites provide a quick access to frequently used components. Some commonly used components or clips can be placed in favorites for quick access. It is also possible to implement a function similar to the control panel. You can add resources to your favorites by right-clicking one or more resources in the repository and selecting Add to Favorites from the context menu.
 
 ![](../../images/20170721153434.png)
 
-**过滤显示包**
+**Filter Display Package**
 
-当库面板里的包比较多时，查找东西比较麻烦。可以把一些不常用的包隐藏起来。点击库面板上的![](../../images/20180202120924.png)
+When there are more packages in the library panel, it's more troublesome to find things. You can hide some of the less commonly used packages. Click on the library panel
 
-**与编辑器链接**
+![](../../images/20180202120924.png)
 
-激活这个功能后，当活动文档发生切换时，会同时在资源库中选中活动文档对应的组件。 
+**Link with Editor**
 
-**快速定位**
+When this function is activated, when the active document is switched, the component corresponding to the active document is also selected in the repository.
 
-按资源名称拼音或者英文的第一个字母，可以在当前选中项的同一层次快速定位到该资源。
+**Rapid Positioning**
 
-**复制、粘贴和粘贴全部**
+Pinyin by resource name or the first letter of English can quickly locate the resource at the same level of the currently selected item.
 
-库里面的资源可以复制粘贴。使用右键菜单中的“复制” “粘贴” “粘贴全部”或者“Ctrl+C” “Ctrl+V”都可以完成。
+**Copy, Paste, and Paste All**
 
-“粘贴”和“粘贴全部”在跨包复制时体现区别。
-- `粘贴全部` 把选定的资源以及它（们）所有引用到的资源一并粘贴过来。
-- `粘贴` 只会粘贴选定的资源以及它（们）引用到但**没有设置为导出**的资源。快捷键为Ctrl+V。
+Resources in the library can be copied and pasted. Use the "Copy" "Paste" "Paste All" or "Ctrl+C" "Ctrl+V" in the right-click menu to complete.
 
-提示：复制、粘贴功能支持跨项目，同时打开两个项目后，就可以互相复制粘贴。
+"Paste" and "Paste All" reflect the difference when copying across packages.
+- `Paste all` Paste the selected resource and all the resources it references.
+- `Paste` will only paste the selected resource and the resources it references (but) are **not set to export**. The shortcut is `Ctrl+V`.
 
-## 主工具栏
+Tip: The copy and paste function is supported across projects. After opening two projects at the same time, you can copy and paste to one another.
+
+## Main Toolbar
 
 ![](../../images/20170726140511.png)
 
-- `屏蔽显示控制器` ![](../../images/20170810222944.png)屏蔽后所有被显示控制器隐藏的内容都会显示出来。
-- `屏蔽关联系统` ![](../../images/20170810222952.png)屏蔽后手动修改元件坐标和大小关联系统不会动作。
-- `提醒信息` ![](../../images/20170810223001.png)如果当前文档内有同名对象，会显示黄色叹号。
-- `在库中显示` ![](../../images/20170810223008.png)点击可在库中定位这个组件。
+- `Mask display controller` ![](../../images/20170810222944.png) All contents hidden by the display controller will be displayed after masking.
+- `Blocking associated system` ![](../../images/20170810222952.png) Manually modifying the component coordinates and size associated with the system doesn't act.
+- `Reminder information` ![](../../images/20170810223001.png) If there's an object with the same name in the current document, a yellow exclamation mark will be displayed.
+- `Show ` ![](../../images/20170810223008.png) in the library to locate this component in the library.
 
-## 侧工具栏
+## Side Toolbar
 
-![](../../images/20170726140818.png) 可以在拖动和选择两种模式间切换。特别的，在选择模式下，按住空格就可以临时切换为拖动模式，释放空格就可以切换为选择模式。
+![](../../images/20170726140818.png) You can switch between drag and drop modes. In particular, in the selection mode, press and hold a space to temporarily switch to the drag mode, and release the space to switch to the selection mode.
 
-![](../../images/20170726140827.png) 基础控件区域。点击后再在舞台上点击一个位置，则在对应位置生成一个对象。
+![](../../images/20170726140827.png) The base control area. Click and then click on a position on the stage to generate an object at the corresponding location.
 
-![](../../images/20170726140837.png) 组合和取消组合。组合的快捷键是Ctrl+G，取消组合的快捷键是Ctrl+Shift+G。
+![](../../images/20170726140837.png) Combine and ungroup. The combined shortcut is Ctrl+G, and the ungrouped shortcut is Ctrl+Shift+G.
 
-![](../../images/20170810223145.png)![](../../images/20170810223153.png)![](../../images/20170810223201.png) 对齐操作。选定多个元件后，再点击这里的按钮，可以执行对应的对齐功能。例如选定两个元件后，点击左右居中，则两个元件将设置为中线对齐。如果只选择了一个元件，则该元件对容器组件执行对应的对齐功能。例如，选定一个元件后，点击左右对齐，则元件将移到容器组件的中间位置。又例如，选定一个元件后，点击相同宽度，则元件的宽度将设置为与容器组件相同。
+![](../../images/20170810223145.png)![](../../images/20170810223153.png)![](../../images/20170810223201.png) Alignment operation. After selecting multiple components, click the button here to perform the corresponding alignment function. For example, after selecting two components and clicking left and right to center, the two components will be set to centerline alignment. If only one component is selected, the component performs a corresponding alignment function on the container-component. For example, after selecting a component and clicking `Align Left and Right`, the component will move to the middle of the container assembly. For another example, after selecting a component and clicking the same width, the component's width will be set to be the same as the container-component.
 
-![](../../images/20170726141549.png) 自定义排列。点击后弹出自定义排列的对话框。
+![](../../images/20170726141549.png) Custom arrangement. Click to pop up the dialog box for custom arrangement.
 
 ![](../../images/20170726141638.png)
 
-## 控制器工具栏
+## Controller Toolbar
 
-![](../../images/20170726142308.png) 
+![](../../images/20170726142308.png)
 
-点击加号可以增加新的控制器。点击控制器名称可以进入控制器编辑界面。点击控制器的各个页面按钮切换页面。
+Click the plus sign to add a new controller. Click on the controller name to enter the controller editing interface. Click the controller's various page buttons to switch pages.
 
-## 动效工具栏
+## Motion Toolbar
 
-![](../../images/20170726142345.png) 
+![](../../images/20170726142345.png)
 
-点击加号可以增加新的动效。点击动效名称可以进入动效编辑界面。
+Click on the plus sign to add new effects. Click on the effect name to enter the motion editing interface.
 
-## 显示列表
+## Display List
 
 ![](../../images/20170727101112.png)
 
-这里显示的当前正在编辑的组件的显示列表。按显示顺序排列，列表中越往下的元件显示在越前面。
-显示列表面板的操作有：
-- 点击每行行头“眼睛”对应的位置可以隐藏元件，仅用于辅助编辑，不影响运行时。
-- 点击每行行头“锁”对应的位置可以锁定元件，锁定后元件无法选中，仅用于辅助编辑，不影响运行时。
-- 点击锁图标可以解锁所有元件。
-- 点击眼睛图标可以解除所有元件的隐藏状态。
-- 在显示列表中拖拽可以改变元件在显示列表中的位置。
+The display list of the components currently being edited is displayed here. In the order in which they are displayed, the lower the component in the list is displayed in front.
+The operations of the display list panel are:
+- Click on the position corresponding to the "eye" of each line head to hide the component, only for auxiliary editing, without affecting the runtime.
+- Click on the position corresponding to the "lock" in each line head to lock the component. After locking, the component cannot be selected, only for auxiliary editing, and doesn't affect the runtime.
+- Click on the lock icon to unlock all components.
+- Click on the eye icon to unhide all components.
+- Drag and drop in the display list to change the position of the component in the display list.
 
-## 舞台
+## Stage
 
 ![](../../images/20170726143302.png)
 
-舞台是组件的编辑区域。添加内容到舞台的方法有：
+The stage is the editing area of ​​the component. Ways to add content to the stage are:
 
-- 侧工具栏上点击基础控件，然后点击舞台。
-- 从资源库或收藏夹中直接拖拽资源到编辑区域。
-- 可直接粘贴剪贴板中的文字或图片。图片会自动导入到资源库，然后再放置到舞台上。
-- 可以从Windows资源管理器或者Finder中直接拖入资源。如果该资源是位于assets目录下的，也就是说已经是包里的资源里，那么对应包里的资源会放置到舞台上，不会发生资源重复导入到资源库的情况。这个设计可以部分解决目前库面板不能显示所有图片缩略图的不便利性，因为在Windows资源管理器或者Finder中你可以方便的查看缩略图，同时，如果你是使用多屏工作，还可以起到类似将库面板放置单独一屏的作用。
+- Click on the base control on the side toolbar and click on the stage.
+- Drag resources directly from the repository or favorites to the editing area.
+- Paste text or images from the clipboard directly. The image is automatically imported into the repository and placed on the Stage.
+- You can drag resources directly from Windows Explorer or Finder. If the resource is located in the assets directory, that is to say, it's already in the resource in the package, then the resources in the corresponding package will be placed on the stage, and there will be no repeated import of resources into the resource library. This design can partially solve the inconvenience that the current library panel can not display all the image thumbnails, because you can easily view the thumbnails in Windows Explorer or Finder, and if you're working with multi-screen, you can also play It is similar to placing the library panel on a separate screen.
 
-中间不同于周边颜色的是组件区域。但你并不需要把所有内容都放置到组件区域内。默认情况下，超出组件区域的内容依然会被显示，但组件的大小仅由组件区域决定。某些特别的功能，例如滤镜，只对组件区域生效，所以建议把内容都放置在组件区域内。
+What's different from the surrounding color in the middle is the component area. But you don't need to put everything in the component area. By default, content that exceeds the component area is still displayed, but the component's size is determined only by the component area. Some special features, such as filters, are only valid for the component area, so it's recommended to place the content in the component area.
 
-常用的舞台操作有：
+Commonly used stage operations are:
 
-- `选定` 点击一个元件单选，按住SHIFT点击多个元件多选。点击空白处取消所有选择。在空白处按下并拖动进行框选。
+- `Selected` Click on a component to single-select, hold down `SHIFT` and click on multiple components to select multiple. Click on the blank to cancel all selections. Press and drag in the blank space to select the box.
 
-- `移动` 按住元件拖动，如果拖动时按住SHIFT，则移动限制在垂直方向或者水平方向。使用键盘上、下、左、右箭头键可以移动选定的元件，每按一次移动1像素，如果同时按下SHIFT键，则移动加速，每次移动10像素。
+- `Move` Press and hold the component to drag. If you hold down `SHIFT` while dragging, the movement is limited to the vertical or horizontal direction. Use the up, down, left, and right arrow keys on the keyboard to move the selected component. Each press moves 1 pixel. If you press the SHIFT button at the same time, the motion is accelerated and moves 10 pixels at a time.
 
-- `缩放` 拖拽选定框边缘的8个调整点，可以改变元件的宽度和高度。
+- `Zoom` Drag and drop the 8 adjustment points on the edge of the selected frame to change the width and component's height.
 
-- `组合` 选定多个元件后，按CTRL+G建立一个组合。
+- `Combination` After selecting multiple components, press `CTRL+G` to create a combination.
 
-**舞台右键菜单**
+**Stage Right-Click Menu**
 
 ![](../../images/20170726144117.png)
 
-- `替换元件` 可以将当前选中的元件替换成另外一个元件，位置大小等所有属性都会保留。
+- `Replace component` You can replace the currently selected component with another component, and all attributes such as position size will be retained.
 
-- `转换为组件` 可以将当前选中的一个或多个元件替换成一个单独的组件，这个组件的内容包括原来选择的内容。
+- `Convert to component` You can replace the currently selected component or components with a single component whose contents include the originally selected content.
 
-- `转换为位图` 可以将当前选中的一个或多个元件替换成一个单独的图片，这个图片的内容由原来选中的内容绘制而成。生成的图片自动加入资源库中。
+- `Convert to bitmap` You can replace the currently selected one or more components with a single image. The content of this image is drawn from the original selected content. The generated image is automatically added to the repository.
 
-- `在库中显示` 在库中高亮显示当前选中的元件。
+- `Show in library` Highlights the currently selected component in the library.
 
-## 预览
+## Preview
 
-点击主工具栏上的![](../../images/20170726145053.png)按钮可以进入预览模式。
+Click the ![](../../images/20170726145053.png) button on the main toolbar to enter preview mode.
 
 ![](../../images/20170726145201.png)
 
-**适配测试**
+**Adaptation Test**
 
 ![](../../images/20170726145236.png)
 
-如果当前设计的组件需要进行适配测试，可以勾选“适配测试”选项。勾选后，如果是第一次测试，需要先点击“整体缩放”按钮，设置好UI自适应的参数。然后再调整本组件的自适应参数进行测试。
-注意：如果你在动效播放的过程中改变屏幕大小，而这个动效有涉及到带适配设置的元件，那么动效可能播放异常。所有请不要在动效播放的过程中改变屏幕大小。
+If the currently designed component requires an adaptation test, check the `"Adaptation Test"` option. After checking, if it's the first test, you need to click the `“Overall Zoom”` button to set the UI adaptive parameters. Then adjust the adaptive parameters of this component to test.
+Note: If you change the screen size during the dynamic playback, and this motion involves components with adaptive settings, the animation may play abnormally. Please don't change the screen size during the animation.
 
-## 属性面板
+## Property Panel
 
-点击舞台中任意一个或多个元件，编辑器右侧将显示对应的属性设置面板。如果你点击舞台的空白处（不点中任何东西），则显示的是容器组件的属性面板。
+Click on any one or more components in the Stage, and the corresponding property settings panel will be displayed on the right side of the editor. If you click on the stage's blank space (don't click anything), the properties panel of the container-component is displayed.
 
 ![](../../images/20170726161112.png)
 
-后续讲解各个资源类型使用方法时再详细介绍这里的属性含义。
+The following explains the meaning of the attributes in detail when you use the methods of each resource type.
 
-## 项目设置对话框
+## Project Settings Dialog
 
-打开项目设置对话框：主菜单“文件”->“项目设置”
+Open the project settings dialog: `Main Menu -> "File" -> "Project Settings"`
 
 ![](../../images/20170727103552.png)
 
-这里可以修改项目的名称和类型。
+Here you can modify the name and type of the project.
 
 ![](../../images/20170727103741.png)
 
-修改文本相关的一些全局设置。
+Modify some global settings related to the text.
 
-- `字体` 设置所有文本的默认字体。可以点击“A”按钮选择系统中其他字体。如果你需要使用ttf文件，请先双击ttf文件，将字体安装到系统，再在这里选择（需要重启编辑器才能看到）。这个字体设置仅用于编辑器内，运行时具体使用什么字体，需要使用UIConfig.defaultFont设定。为了使编辑器效果与运行时效果一致，应该尽量选择相同的字体或者相近的字体。例如：
+- `Font` Sets the default font for all text. You can click on the "A" button to select other fonts in the system. If you need to use the ttf file, please double-click the ttf file, install the font to the system, and select it here (you need to restart the editor to see it). This font setting is only used in the editor. What fonts are used at runtime, you need to use UIConfig.defaultFont settings. In order to make the editor effect consistent with the runtime, you should try to choose the same font or similar font. E.g:
 
 ```csharp
     UIConfig.defaultFont = 'HeiTi';
 ```
 
-- `文字大小方案` 一个游戏或应用中使用的字体大小通常有几种固定的方案，这里定义好后，制作UI时需要设置字体大小时，就可以直接在下拉菜单选择，而不需要每次输入。
+- `Text size scheme` There are usually several fixed schemes for the font size used in a game or application. After defining this, when you need to set the font size when making the UI, you can select it directly in the drop-down menu without having to do it each time. Input.
 
 <center>
 ![](../../images/20170727114115.png)
 </center>
 
-- `禁用字体渲染位置优化` 该选项仅适用于Egret和Laya版本。勾选后，FairyGUI将使用系统渲染文本的默认位置，不再进行自动的优化。这个差别这对于微软雅黑特别明显。这个选项可以帮助解决部分H5引擎渲染字体位置的问题。
+- `Disable font rendering position optimization` This option is only available for Egret and Laya versions. When checked, FairyGUI will use the system to render the default position of the text, no longer automatically optimized. This difference is especially noticeable for Microsoft Yahei. This option can help solve some of the problems with the H5 engine rendering font position.
 
 ![](../../images/20170727103756.png)
 
-设置颜色设置的方案。一个游戏或应用中使用的颜色通常有几种方案，这里定义好后，制作UI时需要设置颜色时，就可以直接在下拉菜单选择，而不需要每次调色。
+Set the scheme for color settings. There are usually several options for the colors used in a game or application. Once you have defined them, you need to set the colors when you make the UI. You can select them directly from the drop-down menu without having to color each time.
 
 ![](../../images/20170727103807.png)
 
-设置编辑器预览用到的一些参数。**注意这些参数仅用于编辑器内，运行时需要用UIConfig重新设置**。
+Set some parameters used by the editor preview. **Note that these parameters are only used in the editor, and you need to reset them with UIConfig at runtime.**
 
-- `垂直滚动条` `水平滚动条` 设置制作UI时所有带滚动功能的容器需要使用的滚动条资源。这就是说，你将一个组件或者一个列表的“溢出处理”设置为“垂直滚动”、“水平滚动”或者“自由滚动”后，不需要每次设置滚动条，自动就会使用这里设置的滚动条资源。如果某个组件需要使用和全局设置不一样的滚动条，编辑器也提供了的单独的设置，后面的章节会另外说明。
+- `Vertical scrollbar` `Horizontal scrollbar` Sets the scrollbar resource that is required for all containers with scrolling functionality when making the UI. That is to say, after you set the "overflow processing" of a component or a list to "vertical scrolling", "horizontal scrolling" or "free scrolling", you don't need to set the scrollbar every time, it will automatically use the scrolling set here. Resources. If a component needs to use a different scrollbar than the global setting, the editor also provides separate settings, which are explained in the following sections.
 
-- `滚动条显示` 滚动条的显示策略。这是全局设置，也可以在组件或者列表的滚动属性设置里单独设置。
-    - `可见` 表示滚动条一直显示。
-    - `滚动时显示` 表示滚动条只有在滚动时才会显示，其他情况下自动隐藏。
-    - `隐藏` 表示滚动条一直不可见的状态，这种情况滚动条也不占用位置。
+- `Scroll bar shows` the display strategy of the scrollbar. This is a global setting and can be set separately in the scrolling property settings of the component or list.
+    - `Visible` means that the scrollbar is always displayed.
+    - `Show when scrolling` means that the scrollbar will only be displayed when scrolling, and will be automatically hidden in other cases.
+    - `Hide` indicates that the scrollbar is always invisible, in which case the scrollbar doesn't occupy the position.
 
-- `TIPS组件` 设定用于显示TIPS的组件。该组件应该扩展为标签。用法参考[这里](object.html#TIPS属性)。
+- `TIPS component` Sets the component used to display TIPS. This component should be expanded to a label. Usage reference [here](object.html#TIPSproperty).
 
-- `按钮点击声音` 设定按钮的默认点击声音。设置后，所有按钮点击都会播放这个声效，除非按钮自己独立设置另外的声效。运行时设置全局按钮点击声音需要通过UIConfig.buttonSound设置。
+- `Button click sound` Sets the default click sound of the button. Once set, all button clicks will play this sound, unless the button itself sets another sound. The global button click sound at runtime needs to be set via UIConfig.buttonSound.
 
 ![](../../images/20170727103829.png)
 
-适配测试设置。详细介绍请阅读[自适应](adaptation.html)。
+Adapt test settings. Please read the detailed introduction[自适应](adaptation.html).
 
 ![](../../images/20170727103847.png)
 
-自定义属性的设置。自定义属性仅供插件开发者使用。运行时不可访问。
+Custom property settings. Custom properties are only available to plugin developers. Not accessible during runtime.
 
-## 偏好设置对话框
+## Preferences Dialog
 
-打开偏好设置对话框：主菜单“编辑”->“首选项”。
+Open the Preferences dialog: `Main Menu -> "Edit" -> "Preferences"`.
 
 ![](../../images/20170727104311.png)
 
-- `导入时自动裁剪图片到最小包围` 如果设置为裁剪，则当图片加入到项目时，自动将周围的全透明区域（透明度为0）剪除。如果设置为不裁剪，而后续又想裁剪，可以双击图片打开图片属性对话框，对话框左下部有提供裁剪的功能按钮。
+- `Automatically crop the image to the minimum bracket when importing`. If set to crop, the image will be automatically clipped off when the image is added to the project. If you set it to not crop, and then want to crop it, double-click the image to open the Picture Properties dialog box. There is a function button that provides cropping at the bottom left of the dialog box.
 
-- `语言` 设置编辑器的界面语言。
+- `Language` Set the interface language of the editor.
 
-- `版本更新` 设置是否自动更新软件。
+- `Version Update` Set whether to automatically update the software.
 
-## 包设置对话框
+## Package Settings Dialog
 
-打开包设置对话框：主菜单“文件”->“包设置”。
+Open the package settings dialog: `Main Menu -> "File" -> "Package Settings"`.
 
 ![](../../images/20170727104354.png)
 
-- `包名称` 查看和修改选定包的名称。
+- `Package Name` View and modify the name of the selected package.
 
-- `JPEG品质` 适用于AS3和Haxe这类不使用图集的项目。当导入JPEG图片后，会自动使用指定的品质进行压缩。其他类型的项目不压缩JPG图片。
+- `JPEG quality` Applicable to projects such as AS3 and Haxe that don't use the Atlas. When a JPEG image is imported, it's automatically compressed with the specified quality. Other types of items don't compress JPG images.
 
-- `压缩PNG` 适用于AS3和Haxe这类不使用图集的项目。勾选后，当导入PNG图片后，会自动将PNG图片压缩为PNG8。你也可以对图片进行单独设置是否压缩，双击图片打开图片属性对话框，调整质量选项。其他类型的项目不压缩PNG图片。
+- `Compressed PNG` Applies to projects such as AS3 and Haxe that don't use the Atlas. After checking, the PNG image will be automatically compressed into PNG8 when the PNG image is imported. You can also set the image separately for compression, double-click the image to open the image properties dialog box, and adjust the quality options. Other types of items don't compress PNG images.
 
-## 发布对话框
+## Publish Settings Dialog
 
-打开发布设置对话框：主菜单“文件”->“发布设置”。或点击主工具栏上的发布按钮旁边的小三角形。
+Open the `Publish Settings dialog`: `Main Menu -> File -> Publish Settings`. Or click the small triangle next to the `Publish` button on the main toolbar.
 
 ![](../../images/20170727143910.png)
 
-左边是包列表，右边是选中包的发布设置。设置分为本包的设置和全局设置，点击右上角的黄色链接进入全局设置。全局设置作用到所有包。
+On the left is the package list, and on the right is the release settings for the selected package. Set the settings and global settings of this package, click the yellow link in the upper right corner to enter the global settings. Global settings apply to all packages.
 
-- `文件名` 发布的文件名。这个文件名与包名称不同。当我们载入包时，需要使用这里设定的文件名，而当创建对象时，需要使用包名称。例如
+- `File name` The name of the file to be published. This file name is different from the package name. When we load the package, we need to use the file name set here, and when creating the object, we need to use the package name. E.g
 
 ```csharp
-    UIPackage.AddPackage('file_name'); //这里是发布的文件名。
-    UIPackage.CreateObject("Package1','Component1'); //这里的Package1是包的名称。
+    UIPackage.AddPackage("file_name"); // Here is the name of the file being published.
+    UIPackage.CreateObject("Package1", "Component1"); // Here Package1 is the name of the package.
 ```
 
-- `发布路径` 发布内容放置的目录。对于Unity平台，**建议直接发布到Unity工程内的目录里**，这样编辑器会自动根据Unity的版本给新发布的纹理提供正确的meta文件。如果不是这样，那么当你手动拷贝到Unity工程里时，请注意自行检查纹理的设置是否符合要求。
-- 
-- `打包方式` 可以选择打包成一个包或者两个包。两个包则将XML定义和图片等资源分开。这样做的好处是如果只修改了组件，没有加入新的素材或删除素材，则可以只发布和推送定义包给用户，减少用户的流量消耗。
+- `Publish path` The directory where the content is posted. For the Unity platform, **it's recommended to be published directly to the directory within the Unity project**, so the editor will automatically provide the correct meta file for the newly released texture based on the version of Unity. If this isn't the case, then when you manually copy into the Unity project, please pay attention to check if the texture settings meet the requirements.
+-
+- `Package mode` You can choose to package into one package or two packages. The two packages separate the resources such as XML definitions and images. The advantage of this is that if you only modify the component (not adding new materials or deleting any materials), you can simply publish and push the definition package to the user, reducing the user's data consumption.
 
-- `生成代码` 生成绑定的代码。生成绑定的代码可以更直观地访问组件的各个节点，但也在一定程序度上会造成美术工作和程序员工作的耦合。
+- `Generate code` to generate the bound code. Generating the bundled code provides more intuitive access to the various nodes of the component, but it also results in a coupling between the art work and the programmer's work.
 
-- `压缩描述文件`  Laya和Egret项目提供了这样一个发布选项，通过此选项可以控制发布的描述文件是否压缩。默认是压缩的。如果你已经使用了web服务器的gzip压缩功能，又或者打包时会自行压缩，那可以选择不压缩的格式。
-  ![](../../images/20180105005321.png)
+- `Compressing the description file` The Laya and Egret projects provide a publishing option that allows you to control whether the published description file is compressed. The default is compressed. If you have already used the gzip compression feature of the web server, or if you compress it yourself, you can choose a format that isn't compressed.
+  ![](../../images/20180105005321.png)
 
-- `使用二进制格式` 发布格式设定为二进制格式。使用二进制格式可以减少降低时载入包的消耗，推荐使用。这种格式需要一定版本以上的SDK支持：Unity-3.0，Cocos2dx-2.0，其他SDK请使用2018年9月后的源码。如果你是从旧的SDK升级，请查看升级说明：[升级到二进制包格式](upgrade_binary_format.html)。
+- `Use binary format` The publishing format is set to binary format. Using the binary format can reduce the consumption of load packets when it's reduced. It is recommended. This format requires a certain version of SDK support: Unity-3.0, Cocos2dx-2.0, other SDKs please use the source code after September 2018. If you're upgrading from an old SDK, please see the upgrade instructions: [Upgrade to Binary Package Format](upgrade_binary_format.html).
 
-- `仅发布定义` 通常发布的内容包括素材（图片、声音等）和XML定义文件， 如果你没有增删改素材，那么你可以仅发布XML定义文件，避免了重新生成图集带来的时间消耗。
+- `Publish only definitions` Usually published content includes material (pictures, sounds, etc.) and XML definition files. If you have not added or deleted material, you can only publish the XML definition file, avoiding the time consumption caused by regenerating the atlas. .
 
-### 纹理集定义
+### Texture Set Definition
 
 ![](../../images/20170727144133.png)
 
-- `None POT` None Power Of Two的简写，勾选后，允许输出纹理的大小**不限定为**二的幂。注意，有些纹理格式规定大小必须为二的幂。
+- `None POT` None Short for Power Of Two, after checking, the size of the output texture allowed **isn't limited to the power of**. Note that some texture formats specify that the size must be a power of two.
 
-- `正方形` 勾选后，限制输出纹理的宽和高相等。
+- `Square` Check to limit the width and height of the output texture to be equal.
 
-- `允许旋转` 允许旋转图片以达到更大的纹理空间利用率。*（Egret和LayaAir平台不支持）*
+- `Allow rotation` Allows you to rotate the image to achieve greater texture space utilization. *(Not supported on Egret and LayaAir platforms)*
 
-- `分离Alpha通道` 这个选项仅适用于Unity。通过此方法，可以在Unity里将原纹理设置为不支持Alpha通道的格式（例如ETC1）以减少内存占用。FairyGUI-unity SDK提供了专门的着色器进行混合。
+- `Separate Alpha Channel` This option is only available for Unity. With this method, you can set the original texture in Unity to a format that doesn't support alpha channel (such as ETC1) to reduce memory usage. The FairyGUI-unity SDK provides specialized shaders for mixing.
 
-- `纹理集定义` 对于支持纹理集的平台，例如Unity/Egret/Starling，你可以规划图片放到不同的纹理集内。这项功能的意义在于：
-  1. 图片太大太多，假设纹理集最大支持2048×2048（这个可调整），超出此范围的你可以使用多个纹理集；
-  2. 图片用途不一致，例如一张尺寸比较大的色彩丰富的背景图就不适合和色彩比较单一的UI素材放到一起，这样会使最终发布的png图片过大。将超大尺寸背景图单独放一张纹理集是一个比较好的解决方案；
-  3. 图片的特性不一致，例如在Unity平台里，你可以为纹理集设置单独的Filter Mode、压缩格式等等。
-  这里只提供10张纹理集的设置，如果一个包的纹理集超过10张，建议考虑分包。
+- `Textset definition` For platforms that support texture sets, such as Unity/Egret/Starling, you can plan to place images in different texture sets. The significance of this feature is:
+  1. The picture is too large, assuming the texture set supports up to 2048×2048 (this is adjustable), you can use multiple texture sets beyond this range;
+  2. The images are inconsistent. For example, a large-sized background image with a large size isn't suitable for putting together a single color UI material, which will make the final png image too large. It is a good solution to put a large size background image on a texture set separately;
+  3. The characteristics of the image are inconsistent. For example, in the Unity platform, you can set a separate Filter Mode, compression format, etc. for the texture set.
+  Only 10 texture set settings are provided here. If a package has more than 10 texture sets, it's recommended to consider subcontracting.
 
-- `压缩` 将纹理使用PNG8格式压缩。这个压缩方式能大大降低PNG文件大小，但也会使图片失真比较严重，特别是色彩比较丰富，或者含有渐变的图片，请谨慎使用。Unity引擎不要使用这个压缩功能，因为Unity对纹理的压缩应该在Unity里设置，Unity在打包时会自动根据设置的格式压缩纹理，使用这里的压缩除了降低图片质量外没有任何减少文件体积的作用。
+- `Compress` compresses textures using the PNG8 format. This compression method can greatly reduce the size of the PNG file, but it will also make the image distortion more serious, especially the color is rich, or contains gradient pictures, please use with caution. The Unity engine shouldn't use this compression function, because Unity's texture compression should be set in Unity. Unity will automatically compress the texture according to the format set when packaging. The compression used here doesn't reduce the file size except the image quality.
 
-### 资源排除设置
+### Resource Exclusion Settings
 
 ![](../../images/20170727144149.png)
 
-如果一些素材，只用于测试用途，例如一个装载器，放一个图片进去只用于看效果，但这个图片是不随包发布的（后续可能通过外部加载），那么可以在这个界面里将这个图片拖入，那么发布时就不会包含这个图片了。
+If some material is only used for testing purposes, such as a loader, put an image into it only to see the effect, but this image isn't released with the package (subsequently through external loading), then you can put this image in this interface. Drag in, then the image won't be included when it's released.
 
-### 发布代码设置
+### Publish Settings
 
 ![](../../images/20170727144103.png)
 
-- `代码保存路径` 发布的代码保存的路径。
+- `File Path` The path to the saved code.
 
-- `组件名前缀` 给每个组件生成的类名加上前缀。例如如果组件名为“Component1”，这里设置前缀为“T”，那么最后生成的类名为“TComponent1”。前缀可以为空。注意，如果组件名是中文，会被自动转换为拼音。
+- `Class Name Prefix` prefixes the class name generated by each component. For example, if the component name is "Component1" and the prefix is ​​set to "T", then the last generated class name is "TComponent1". The prefix can be empty. Note that if the component name is Chinese, it will be automatically converted to Pinyin.
 
-- `成员名称前缀` 给组件里每个元件的名称前加上前缀。例如如果元件名称为“n10”，这里设置前缀为“m_”，那么最后生成的类成员的名称为“m_n10”。前缀可以为空，但不建议这样做。因为元件名称很可能和类的一些属性和方法名称冲突。例如，如果元件名称为“icon”，那就和GObject的icon属性冲突了。
+- `Member Name Prefix` Prefix the name of each component in the component. For example, if the component name is "n10" and the prefix is ​​set to "m_", the name of the last generated class member is "m_n10". The prefix can be empty, but this isn't recommended. Because the component name is likely to conflict with some of the class's properties and method names. For example, if the component name is "icon", it conflicts with the icon property of GObject.
 
-- `不生成使用默认名称的成员` 勾选后，对于"n1","n2"等这种系统自动生成的名称，或者“title”，“icon”等这种扩展组件里约定的名称，将不会为这些名称的元件生成成员获取代码。如果一个组件里，全部都是这些名称的元件，那么整个组件都不会生成代码。例如，一个按钮，里面只有名称为“title”和“icon”的元件，则不会为这个按钮生成代码，因为使用基类GButton已经足够。
+- `Ignore not renamed child`. When checked, the names automatically generated by such systems such as "n1", "n2", or the names of the extensions such as "title", "icon", etc. will be Member acquisition codes aren't generated for components of these names. If a component is a component of these names, then the entire component will not generate code. For example, a button with only the symbols named "title" and "icon" will not generate code for this button, because using the base class GButton is sufficient.
 
- - `使用名称获取成员对象` 如果不勾选，组件初始化时使用索引获得子对象；如果勾选，则使用名称获得子对象。前者效率高，推荐使用；后者则兼容性较好，例如，如果调整了元件的顺序，不会发生异常。
+ - `Use name to get child` If unchecked, the component is initialized with the index to get the child object; if checked, the child object is obtained with the name. The former is highly efficient and recommended; the latter is more compatible, for example, if the order of the components is adjusted, no anomalies will occur.
 
-- `包名称` 对于AS3代码，是指发布的代码的package；对于C#代码，是指发布的代码的namespace；对于Typscript代码，是指发布的代码的module；对于C++代码，是指发布的代码的namespace。
+- `Package Name` For AS3 code, the package of the released code; for C# code, the namespace of the released code; for Typscript code, the module of the released code; for C++ code, the code for the release Namespace.
 
-- `代码类型` 对于Laya引擎，你可以选择发布AS3代码还是TS代码。
+- `Code Type` For the Laya engine, you can choose to publish the AS3 code or the TS code.
 
-使用发布出来的代码的方式：
+The way to use the published code:
 
 ```csharp
-    //首先要调用BindAll。发布出来的代码有个名字为XXXBinder的文件
-    //注意：一定要在启动时调用。
+    // First call BindAll. The released code has a file named XXXBinder
+    // Note: Be sure to call it at startup.
     XXXBinder.BindAll();
 
-    //创建UI界面。注意：不是直接new XXX。
+    // Create a UI interface. Note: Not directly new XXX.
     XXX view = XXX.CreateInstance();
     view.m_n10.text = ...;
 ```
 
-发布代码时会用到代码模板。代码模板在编辑器安装目录下的template目录下。如果你需要自定义模板，需要将template目录拷贝到UI项目的根目录下，再做修改。模板里支持的参数有：
+The code template is used when publishing the code. The code template is in the template directory under the editor installation directory. If you need a custom template, you need to copy the template directory to the root of the UI project and make changes. The parameters supported in the template are:
 
 ```csharp
     Component.template
     -------------
-    {packageName} UI模块名
-    {componentName} UI组件父类名
-    {className} UI组件类名
-    {uiPkgName} UI资源包名
-    {uiResName}UI资源名
-    {uiPath} UI资源路径
-    
+    {packageName} UIModuleName
+    {componentName} UIComponentParentClassName
+    {className} UIComponentClassName
+    {uiPkgName} UIResourcePackageName
+    {uiResName} UIResourceName
+    {uiPath} UIResourcePath
+
     Binder.template
     -------------
-    {className}  UI模块名+"Binder"
-    {packageName} UI模块名
+    {className}  UIModuleName+"Binder"
+    {packageName} UIModuleName
 ```
 
-## 依赖关系查询对话框
+## Dependency Query Dialog
 
-在资源库里，点击一个资源后，右键菜单点击“依赖关系查询”，或者在主菜单“工具”->“依赖关系查询”，可以打开依赖关系查询对话框。
+In the repository, click on a resource, right-click on the `"Dependency Query"` menu, or in `Main Menu -> "Tools" -> "Dependency Query"`, to open the Dependency Query dialog box.
 
 ![](../../images/20170727144223.png)
 
-在这里可以查询资源之间的依赖关系。
+Querying the dependencies between resources:
 
 ![](../../images/20170727144240.png)
 
-如果查询出A资源被B、C、D组件引用，那么可以将这些组件里的A替换成其他资源。
+If the A resource is queried by the B, C, and D components, then the A in these components can be replaced with other resources.
 
-## 导入和导出资源包
+## Import and Export Resource Bundles
 
-- `导出资源包`
+- `Export Resource Bundles`
 
-在资源库里选定一个或者多个资源，也可以选定文件夹或包，然后点击主菜单“资源”->“导出资源”：
+Select one or more resources in the repository, or select a folder or package, then click on `Main Menu -> "Resources" -> "Export Resources"`:
 
 ![](../../images/20170810111638.png)
 
-这里列出了选定的资源以及它（们）依赖的资源，点击导出，生成一个扩展名为fairypackage的文件。
+Here is a list of selected resources and the resources they depend on. Click Export to generate a file with the extension fairpackage.
 
-- `导入资源包`
+- `Import Resource Bundles`
 
-点击主菜单“资源”->“导入资源”，然后按提示选择一个扩展名为fairypackage的文件。
+Click on `Main Menu -> "Resources" -> "Import Resources"` and follow the prompts to select a file with the extension fairpackage.
 
 ![](../../images/20170810112536.png)
 
-选择导入的位置，然后点击导入，fairypackage里的资源导入得到指定的位置。
+Select the imported location, then click Import, and the resources in the fairypackage are imported to get the specified location.
 
-- `导入内置的资源包` FairyGUI自带了几套皮肤，点击主菜单“资源”->“导入内置的资源包”，然后选择其中一个包导入即可。例如BlueSkin.fairypackage包含的内容有：
+- `Import Built-in Resource Bundles` FairyGUI comes with a few sets of skins, click on `Main Menu -> "Resources" -> "Import built-in resource bundles"`, and then select one of the packages to import. For example, `BlueSkin.fairypackage` contains:
 
 ![](../../images/20170810125620.png)
 
-## 字符串导入和导出
+## String Import and Export
 
-使用FairyGUI编辑器可以使你的游戏支持多种语言成为一件轻松的事。
+Using the FairyGUI editor makes it easy to support multiple languages in your game.
 
-点击菜单“工具”->”字符串导入与导出”，弹出窗口如下图：
+Click on `Main Menu -> "Tool" -> "String Import and Export"`, pop-up window as shown below:
 
 ![](../../images/20170807165657.png)
 
-使用”导出所有字符串到文件“功能，完成后得到一个xml文件，
+Use the "Export all strings to file" function, get an xml file after you finish,
 
 ![](../../images/20170807165753.png)
 
-这个文件包含了在UI上出现的所有文字（排除了纯阿拉伯数字），然后可以将此文件提交翻译，翻译完毕后，我们有两种方式使新的语言文件生效：
+This file contains all the text that appears on the UI (excluding pure Arabic numerals), and then this file can be submitted for translation. After the translation, we have two ways to make the new language file take effect:
 
-“如果导出目标文件已存在，与目标文件合并”：这个选项表示，比如现在导出内容中包含1个id为x1的字符串，值为a，而目标文件也存在一个id为x1的字符串，值为b，则导出的结果文件里，x1的值为b。
+"If the export target file already exists, merge with the target file": This option means that, for example, the output contains a string with an id of x1, the value is a, and the target file also has a string with the id x1. The value is b, and the value of x1 in the exported result file is b.
 
-- 使用上述窗口的字符串导入功能，直接将翻译好的文件导回到编辑器，则UI上的文字将全部被替换。这种方法适用于每种语言使用一个项目的方式。
+- Using the string import function of the above window, directly import the translated file back to the editor, the text on the UI will be completely replaced. This method is suitable for the way each project uses one project.
 
-- 运行时动态加载语言文件。这种方法相对比较灵活。
+- Dynamically load language files at runtime. This method is relatively flexible.
 
 ```csharp
-    //Unity
+    // Unity
 
-    string fileContent; //自行载入语言文件，这里假设已载入到此变量
+    string fileContent; // Load the language file yourself, assuming it has been loaded into this variable
     FairyGUI.Utils.XML xml  = new FairyGUI.Utils.XML(fileContent);
     UIPackage.SetStringsSource(xml);
 ```
 
 ```csharp
-    //AS3
+    // AS3
 
-    var fileContent:String;//自行载入语言文件，这里假设已载入到此变量
+    var fileContent:String; // Load the language file yourself, assuming it has been loaded into this variable
     var xml:XML = new XML(fileContent);
     UIPackage.setStringsSource(xml);
 ```
 
-## 编辑器插件
+## Editor Plugin
 
-点击菜单“工具”->”插件管理”，弹出窗口如下图：
+Click on `Main Menu -> "Tools" -> "Plugin Management"`, pop-up window as shown below:
 
 ![](../../images/20170810113630.png)
 
-这里列出了编辑器已装载的插件。目前只能使用AS3语言编写编辑器插件，而且插件能做的东西也非常有限，不建议使用。如果确实需要编写插件，目前只有一个资料可供参考：[编辑器插件怎么写？](http://ask.fairygui.com/?/question/5)
+这里列出了编辑器已装载的插件。目前只能使用AS3语言编写编辑器插件，而且插件能做的东西也非常有限，不建议使用。如果确实需要编写插件，目前只有一个资料可供参考:[编辑器插件怎么写？](http://ask.fairygui.com/?/question/5)
 
-## 命令行发布
+## Command-line Publishing
 
-支持命令行发布（实验性功能）：
+Support for command-line publishing (experimental features):
 
+```
 FairyGUI-Editor -p project_desc_file [-b package_names] [-x callback] [-o output_path]
+```
 
-project_desc_file：项目描述文件路径，例如d:\a\1.fairy。
-package_names: 可选。不提供则为所有包，多个包用逗号隔开。
-callback：可选。发布完毕后调用这个程序。
-output_path：可选。如果指定，则覆盖项目里的设置，直接使用这里指定的位置。
+* project-desc-file: Project description file path, such as d:?a.1.fairy.
+* package-names: Optional. Not available for all packages, multiple packages separated by commas.
+* callback: Optional. Call the program after the publishing is complete.
+* output-path: optional. If specified, override the project settings, using the location specified here directly.

--- a/src/guide/editor/label.md
+++ b/src/guide/editor/label.md
@@ -4,18 +4,18 @@ type: guide_editor
 order: 120
 ---
 
-标签组件非常简单，它没有特殊的行为，他可以通过放入title元件和icon元件为组件提供标题和图标属性。
+The `Label` component is very simple, it has no special behavior. You can provide `title` and `icon` properties for the component by placing a component named "title" and a component named "icon".
 
-## 创建标签
+## Create Labels
 
-可以通过两种方式创建标签组件。
+There are two ways to create a label component.
 
-- 点击主菜单“资源”->“新建标签”。
-- 新建一个组件，然后在组件属性里选择扩展为“标签”。
+- Click on `Main Menu -> "Resources" -> "New Tab"`.
+- Create a new component and select `Expand as "Label"` in the component properties.
 
-## 设计属性
+## Design Properties
 
-在组件编辑状态下，标签组件的属性面板是：
+In the component editing state, the properties panel of the label component is:
 
 ![](../../images/20170803135953.png)
 
@@ -25,11 +25,11 @@ order: 120
 
 - `icon` 可以是装载器，也可以是标签、按钮。
 
-注意：标签组件内并非只能有“title”和“icon”，你可以放置任何元件，例如放置任意多的文本、装载器等。“title”和“icon”的设定只是用于标签组件在编辑器实例化时能够直观设置而已。
+注意:标签组件内并非只能有“title”和“icon”，你可以放置任何元件，例如放置任意多的文本、装载器等。“title”和“icon”的设定只是用于标签组件在编辑器实例化时能够直观设置而已。
 
 ## 实例属性
 
-在舞台上选中一个标签组件，右边的属性面板列表出现：
+在舞台上选中一个标签组件，右边的属性面板列表出现:
 
 ![](../../images/20170803140710.png)
 
@@ -46,15 +46,15 @@ order: 120
 
 ## GLabel
 
-设置标签的标题或者图标，你甚至不需要强制对象为GLabel的类型，直接用GObject提供的接口就可以，例如：
+设置标签的标题或者图标，你甚至不需要强制对象为GLabel的类型，直接用GObject提供的接口就可以，例如:
 
 ```csharp
     GObject obj = gcom.GetChild("n1");
     obj.text = "hello";
-    obj.icon = "ui://包名/图片名";   
+    obj.icon = "ui://包名/图片名";
 ```
 
-修改标题颜色可以这样：
+修改标题颜色可以这样:
 
 ```csharp
     GLabel label = gcom.GetChild("n1").asLabel;

--- a/src/guide/editor/popup.md
+++ b/src/guide/editor/popup.md
@@ -4,92 +4,92 @@ type: guide_editor
 order: 200
 ---
 
-在UI系统中我们经常需要弹出一些组件，这些组件在用户点击空白地方的情况下就会自动消失。FairyGUI内置了这个功能。
+In the UI system we often need to pop up some components that will automatically disappear when the user clicks on a blank place. FairyGUI has this feature built-in.
 
-## Popup 管理
+## Popup Management
 
-弹出和关闭Popup的API在GRoot中提供。
+The show and close APIs for `Popup` are available in `GRoot`.
 
-- `ShowPopup` 弹出一个组件。如果指定了目标，则会调整弹出的位置到目标的下方，形成一个下拉的效果。同时提供了参数可以用来指定是向上弹出或者向下弹出。FairyGUI会根据组件的大小自动计算弹出位置，以确保组件显示不会超出屏幕。例如：
+- `ShowPopup` pops up a component. If a target is specified, the pop-up position is adjusted below the target to form a drop-down effect. At the same time, parameters are provided to specify whether to pop up or pop down. FairyGUI automatically calculates the pop-up position based on the size of the component to ensure that the component display doesn't exceed the screen. E.g:
 
 ```csharp
-    //弹出在当前鼠标位置
+    // Pop up at the current mouse position
     GRoot.inst.ShowPopup(aComponent);
 
-    //弹出在aButton的下方
+    // Pop up under the aButton
     GRoot.inst.ShowPopup(aComponent, aButton);
 
-    //弹出在自定义的位置
+    // Pop up in a custom location
     GRoot.inst.ShowPopup(aComponent);
     aComponent.SetXY(100, 100);
 ```
 
-窗口也可以通过ShowPopup弹出，这样弹出的窗口也具有了点击空白关闭的特性：
+The window can also be popped up via `ShowPopup`, so that the pop-up window also has the feature of clicking the blank to close:
 
 ```csharp
     Window aWindow;
     GRoot.inst.ShowPopup(aWindow);
 
-    //和使用aWindow.Show显示窗口的唯一区别就是多了点击空白关闭的功能，其它用法没有任何区别。
+    // The only difference between using the aWindow.Show display window is that there is more click-to-blank off functionality. There is no difference in other usages.
 ```
 
-- `HidePopup` 默认情况下，用户点击空白地方就会自动关闭弹出的组件。也可以调用此API手工关闭。可以指定需要关闭的Popup，不指定参数时，所有当前的弹出都关闭。
+- `HidePopup` By default, when a user clicks on a blank space, the pop-up component is automatically closed. You can also call this API to close it manually. You can specify the `Popup` that needs to be closed. When no parameters are specified, all current popups are closed.
 
-点击空白处后弹出框会自动关闭，如果要获得这个关闭的通知，可以监听移出舞台的事件，例如：
+After clicking in the blank space, the popup will automatically close. If you want to get this notification of closing, you can listen to events that move out of the stage, for example:
 
 ```csharp
-    //Unity/Cry
+    // Unity/Cry
     aComponent.onRemoveFromStage.Add(onPopupClosed);
 
-    //AS3
+    // AS3
     aComponent.addEventListener(Event.REMOVED_FROM_STAGE, onPopupClosed);
 
-    //Egret
+    // Egret
     aComponent.addEventListener(egret.Event.REMOVED_FROM_STAGE, this.onPopupClosed, this);
 
-    //Laya
+    // Laya
     aComponent.on(laya.events.Event.UNDISPLAY, this, this.onPopupClosed);
 
-    //Cocos2dx
+    // Cocos2dx
     aComponent->addEventListener(UIEventType::Exit, CC_CALLBACK_1(AClass::onPopupClosed, this));
 ```
 
 ## PopupMenu
 
-PopupMenu是FairyGUI提供的一个工具类，用于实现弹出菜单。首先需要在编辑器制作一个菜单组件，点击“资源->新建弹出菜单..."，然后根据向导完成。菜单组件里的关键元素是命名为`list`的列表组件，列表的溢出处理模式应该选择为可见，因为一般来说，菜单都是显示全部item的，不需要滚动。
+`PopupMenu` is a tool class provided by FairyGUI for implementing pop-up menus. First you need to make a menu component in the editor. Click on `"Resources -> New Popup Menu..."` and follow the wizard. The key element in the menu component is the list component named `list`. The overflow processing mode of the list should be selected to be visible, because in general, the menus display all items and do not need to be scrolled.
 
-菜单组件制作完成后，可以在代码里生成和调用这个菜单。
+Once the menu component is created, it can be generated and called in the code.
 
-首先设置全局的菜单资源：
+First set the global menu resources:
 ```csharp
-    UIConfig.popupMenu = "ui://包名/菜单组件名";
-    
-    //如果有设计分隔条
-    UIConfig.popupMenu_seperator = "ui://包名/菜单分隔条";
+    UIConfig.popupMenu = "ui://PackageName/MenuComponentName";
+
+    // If there is a menu divider
+    UIConfig.popupMenu_seperator = "ui://PackageName/MenuDivider";
 ```
 
 ```csharp
-    //如果构造函数不带参数，则表示使用UIConfig.popupMenu里定义的资源。
-    //也可以带一个参数，指定这个菜单使用的菜单组件资源
+    // If the constructor takes no arguments, it means using the resources defined in UIConfig.popupMenu.
+    // can also take a parameter, specify the menu component resources used by this menu
     PopupMenu menu = new PopupMenu();
 
-    //如果要修改菜单的宽度。
+    // Modifying the menu width
     menu.contentPane.width = 300;
 
-    //添加一个菜单item，并注册点击回调函数
+    // Add a menu item and register the click callback function
     GButton item = menu.AddItem("标题", MenuItemCallback);
     item.name = "item1";
 
-    //点击回调函数，context.data是当前被点击的item
+    // Click on the callback function, context.data is the currently clicked item
     void MenuItemCallback(EventContext context)
     {
         GButton item = GButton(context.data);
         Debug.Log(item.name);
     }
 
-    //添加分隔条
+    // Add divider
     menu.AddSeperator();
 
-    //设置菜单项变灰
+    // Setting menu items are grayed out
     menu.SetItemGrayed("item1", true);
 ```

--- a/src/guide/editor/relation.md
+++ b/src/guide/editor/relation.md
@@ -4,172 +4,172 @@ type: guide_editor
 order: 110
 ---
 
-关联系统是FairyGUI实现自动布局的核心技术。其他UI框架提供的布局系统，一般只提供各种固定的layout，或者锚点，都只能定义元件与容器之间的关系。而FairyGUI的关联能够定义任意两个元件的关系，而且互动方式更多样。
+The `Relation` system is the core technology for FairyGUI to achieve an automatic layout. The layout system provided by other UI frameworks generally only provide a variety of fixed layouts, or anchor points, which can only define the relationship between `Component`s and containers. The FairyGUI `Relation` can define the relationship between any two `Component`s, and the interaction is more varied.
 
-## 设置关联
+## Set Relation
 
-选定一个元件，可以看到在右边的属性栏出现了关联面板：
+Select a `Component` and you can see that the associated `Relation` panel appears in the property bar on the right:
 
 ![](../../images/20170802232618.png)
 
-关联的目标可以是当前容器中的任意一个元件，也可以是正在编辑的容器本身（称为容器组件）。
-如果要设置的目标是容器组件，则点击![](../../images/20170802232707.png)就能快速完成设置，如果是其他元件，则点击“点击设置”就可以进入到选择目标元件的界面，这时我们就可以从左边的编辑区域选择目标对象，如果点击舞台的空白处，则选择的是容器组件。选择结束后，点击“完成”完成设置。
+The `Relation`'s target can be any `Component` in the current container, or the container *itself* being edited (called a "container-component").
+如果要设置的目标是容器组件，则点击![](../../images/20170802232707.png)You can complete the setup quickly. If it is another component, click “Click Settings” to enter the interface of selecting the target component. At this time, we can select the target object from the editing area on the left. If you click on the blank space of the Stage, select `Is The Container Component`. When the selection is complete, click “Finish” to complete the setup.
 
 ![](../../images/20170802232841.png)
 
-目标对象设置好后，就可以设置自己和目标的关联关系。有两个下拉框可以进行这种选择。左右两个下拉框是相同功能的，每个目标你可以设置一个或两个关联关系（如果两个不够，就在下面的关联子面板继续选择这个目标）。FairyGUI支持设置任意数量的关联目标。
+Once the target object is set up, you can set up your own relationship with the target. There are two drop-down lists for this selection. The left and right drop-down lists are the same function. You can set one or two `Relation`s for each target (if the two are not enough, continue to select this target in the associated sub-panel below). FairyGUI supports setting any number of associated targets.
 
 ![](../../images/20170802232935.png)
 
-关联关系的类型有：（为论述方便，这里假设自己是A，目标元件是T）
+The types of `Relation`s are: (for the convenience of discussion, assume that you are `A` and the target component is `T`)
 
-- `左->左` 假设原来T和A的左侧距离是X，当T的左侧位置变化时，保持T和A的左侧距离为X。注意：与容器组件关联左->左是没有意义的，因为元件在容器中，而容器组件的位置变化是整个容器的移动，并不会影响容器内部所有元件的坐标。
+- `左->左` Suppose that the left distance of the original `T` and `A` is X, and when the left position of `T` changes, the left distance of `T` and `A` is kept X. Note: Giving the container-component a `Left->Left` `Relation` is meaningless because the component is *in* the container, and the change in position of the container-component is the movement of the entire container and doesn't affect the coordinates of all components inside the container.
 
-- `左->中` 假设原来T的中心点和A的左侧距离是X，当T的中心点发生位移时，保持T的中心点和A的左侧距离为X。这里T的中心点发生位移有两种情况，一是T发生位移，二是T的宽度增大。
+- `左->中` Suppose that the distance between the center point of the original `T` and the left side of `A` is X. When the center point of `T` is displaced, the distance between the center point of `T` and the left side of `A` is X. Here, there are two cases in which the center point of `T` is displaced. One is that `T` is displaced, and the other is that the width of `T` is increased.
 
-举例说明，下面的文本是自动增大的，图标与文本建立了一个左->中的关联，所以当文字变化时，图标保持在了文本的中心：
+For example, the text below is automatically incremented, and the icon establishes a left->in `Relation` with the text, so when the text changes, the icon remains at the center of the text:
 
 ![](../../images/20170802000000.jpg)
 
-注意：关联只有在目标的位置或大小发生变化时才起作用。比如上例，设置图标关联文本的左->中，并不意味着就是居中，图标的初始位置是要自己设置的。这是初学者比较容易犯的错误。再强调一下，它只是保持T的中心点和A的左侧距离。那么看下面这个示范：
+Note: `Relation`s only work if the location or size of the target changes. For example, in the above example, setting the `Left->Middle` Relation for the icon's text doesn't mean that it's centered. The initial position of the icon is set by itself. This is a mistake that beginners are more likely to make. Again, it just keeps the center point of T and the left side of A. Then look at the demonstration below:
 
 ![](../../images/20170802000001.jpg)
 
 依然是建立的左->中关联，这次我们把图标往左挪动了一点，可以看到，文本长度发生变化后，图标的位置与文本中线的位置保持不变。
 
-- `左->右` 假设原来T的右侧和A的左侧距离是X，当T的右侧发生位移时，保持T的右侧和A的左侧距离为X。这里T的右侧发生位移有两种情况，一是T发生位移，二是T的宽度增大。咋一看，似乎和左->中没有区别，但在复杂的应用场景中，左->右有发挥作用的空间。举例说明：
+- `左->右` It's assumed that the distance between the right side of the original T and the left side of A is X, and when the right side of T is displaced, the distance between the right side of T and the left side of A is X. Here, there are two cases of displacement on the right side of T. One is that T is displaced, and the other is that the width of T is increased. At first glance, it seems that there's no difference with `Left->`, but in complex application scenarios, `Left->Right` has a functioning space. For example:
 
 ![](../../images/20170802000002.jpg)
 
-这里有一个左右居中的关联，下面会说明，暂且不表。置可以看到，在文本内容发生变化时，文本的中线位置没有发生变化，位所以问号图标的置不变；但文本的右侧位发生了变化，所以叹号图标随之发生了移动，保持了与文本右侧的距离。
+There is a left-and-right-centered `Relation` here, as explained below, not for the time being. As we can see, when the text content changes, the position of the text's center line doesn't change, so the question-mark icon's position remains unchanged; but the right bit of the text changes, so the exclamation mark icon moves and remains. The distance from the right side of the text.
 
-- `左右居中` 假设原来T的中心和A的中心距离是X，当T的中心发生位移时，保持T的中心和A的中心距离为X。这里T的中心发生位移有两种情况，一是T发生位移，二是T的宽度增大。举例说明：
+- `左右居中` 假设原来T的中心和A的中心距离是X，当T的中心发生位移时，保持T的中心和A的中心距离为X。这里T的中心发生位移有两种情况，一是T发生位移，二是T的宽度增大。举例说明:
 
 ![](../../images/20170802000003.jpg)
 
-文本建立了一个与容器组件的左右居中关联，可以看到，当组件变宽时，文本依然保持了中间的位置。这里再提醒一次，左右居中关联并不等同与居中，文本可以放置在任何位置。关联只是保证中线距离一直不变。
+The text establishes a left-right centering `Relation` with the container-component. As you can see, the text remains in the middle when the component is widened. Again, the left-and-right-centered `Relation`s are not equivalent to centering, and the text can be placed anywhere. The `Relation` is only to ensure that the midline distance remains the same.
 
-- `右->左` 假设原来T的左侧和A的右侧距离是X，当T的左侧发生位移时，保持T的左侧和A的右侧距离为X。”右“系列的关联还有一个特点，就是如果A的宽度发生改变时，A也会自动移动以保持X不变。举例说明：
+- `右->左` It's assumed that the distance between the left side of the original `T` and the right side of `A` is X, and when the displacement of the left side of `T` occurs, the distance between the left side of `T` and the right side of `A` is X. Another feature of the "right" series is that if `A`'s width changes, `A` will automatically move to keep X unchanged. For example:
 
 ![](../../images/20170802000004.jpg)
 
-这里文本建立了一个与问号图标的右->左关联，当文本内容发生变化时，文本的宽度发生了变化，正常来说，宽度发生变化后文本应该向右侧伸展，但为了保持文本的右侧与问号左侧距离不变，文本自动向左延伸，提示：本例中文本与容器组件建立一个右->左关联也是同样效果的。
+The text here establishes a `Right->Left` `Relation` with the question-mark icon. When the text's content changes, the text's width changes. Normally, the width should change to the right after the width changes, but in order to keep the text right the distance between the side and the left side of the question mark doesn't change, and the text automatically extends to the left. Tip: In this case, the text and the container-component establishes a `Right->Left` `Relation` with the same effect.
 
 - `右->中` 假设原来T的中心和A的右侧距离是X，当T的中心发生位移时，保持T的中心和A的右侧距离为X。
 
 - `右->右` 假设原来T的右侧和A的右侧距离是X，当T的右侧发生位移时，保持T的右侧和A的右侧距离为X。
 
-- `左延展->左` 假设T的左侧和A的左侧的距离是X，当T的左侧发生位移时，A的左侧会发生移动，但保持A的右侧不变，也就是A产生一个延展（宽度变化）的效果。举例说明：
+- `左延展->左` 假设T的左侧和A的左侧的距离是X，当T的左侧发生位移时，A的左侧会发生移动，但保持A的右侧不变，也就是A产生一个延展（宽度变化）的效果。举例说明:
 
 ![](../../images/20170802233918.png)
 
-绿色方块建立了一个与白色方块左延展->左的关联。
+The green square establishes a `Left Extension->Left``Relation` with the white square.
 
 ![](../../images/gaollg20.gif)
 
-当白色方块向左移动时，绿色方块的左侧跟随白色方块移动，但绿色方块的右侧保持不动，效果就是绿色方块被拉长了。
+When the white square moves to the left, the left side of the green square follows the white square, but the right side of the green square remains motionless. The effect is that the green square is elongated.
 
 - `左延展->右` 假设T的右侧和A的左侧的距离是X，当T的右侧发生位移时，A的左侧会发生移动，但保持A的右侧不变，也就是A产生一个延展（宽度变化）的效果。
 
 - `右延展->左` 假设T的左侧和A的右侧的距离是X，当T的左侧发生位移时，A的右侧会发生移动，但保持A的左侧不变，也就是A产生一个延展（宽度变化）的效果。
 
-- `右延展->右` 假设T的右侧和A的右侧的距离是X，当T的右侧发生位移时，A的右侧会发生移动，但保持A的左侧不变，也就是A产生一个延展（宽度变化）的效果。右延展->右一般也用来做容器的自动扩展。举例说明：
+- `右延展->右` 假设T的右侧和A的右侧的距离是X，当T的右侧发生位移时，A的右侧会发生移动，但保持A的左侧不变，也就是A产生一个延展（宽度变化）的效果。右延展->右一般也用来做容器的自动扩展。举例说明:
 
 ![](../../images/20170802234354.png)
 
-这里容器组件设置了一个对文本的右延展->右关联（设置容器组件的关联的方法是点击编辑器区域的空白处，也就是不要选中任何元件，右侧就会出现容器组件的关联设置），这表示当文本扩展时，容器组件的宽度随之增大。
+Here the container-component sets a right extension to the text -> right `Relation` (the way to set the container-component's `Relation` is to click in the blank space of the editor area. That is, do not select any components, and the container-component's associated settings will appear on the right side) , which means that as the text expands, the container-component's width increases.
 
 ![](../../images/20170802234450.png)
 
-当容器组件建立了对文本右延展的关联后，容器组件的宽度就由文本的宽度决定了。所以当这个组件被拖到其他地方使用时，它的宽度就无法手工改变了，拉大拉小或者直接输入宽度都没有作用。
+When the container-component establishes a `Relation` to the right extension of the text, the container-component's width is determined by the text's width. So when this component is dragged to other places, its width cannot be changed manually. Pulling small or directly inputting the width has no effect.
 
 - `宽->宽`
-假设T的宽度和A的宽度的差是X，当T的宽度发生变化时，A的宽度发生相同的变化。举例说明：
+Assuming that the difference between the `T`'s width and `A`'s width is X, when the width of `T` changes, the width of `A` changes the same. For example:
 
 ![](../../images/20170802234604.png)
 
-背景图片与容器组件建立了宽->宽关联。
+The background image establishes a `Width->Width` `Relation` with the container-component.
 
 ![](../../images/20170802234450.png)
 
-现在我们把制作好的组件拿出来使用，可以看到，当组件被拉宽时，图标的宽度也随之被拉宽。如果我们没有设置关联，那么效果是这样的：
+Now that we have taken the finished component out, we can see that when the component is stretched, the icon gets wider. If we don't set the `Relation`, the effect is this:
 
 ![](../../images/20170802234710.png)
 
-- `顶->顶` `顶->中` `顶->底` `上下居中` `底->顶` `底->中` `底->底` `顶延展->顶` `顶延展->底` `底延展->顶` `底延展->底` `高->高` 这些关联的设置方法和特性都和上述的关联相同，只是从横向变成纵向而已，在此不再赘述。
+- `顶->顶` `顶->中` `顶->底` `上下居中` `底->顶` `底->中` `底->底` `顶延展->顶` `顶延展->底` `底延展->顶` `底延展->底` `高->高` The setting methods and characteristics of these `Relation`s are the same as those described above, but only from the horizontal to the vertical, and will not be described here.
 
-- `使用百分比` 从上面的论述可以看到，关联总是在保持设定好的距离，这个距离是绝对距离，是像素的距离。有时候我们需要的是成比例的距离。FairyGUI提供了这样一个功能，在设置关联时，可以使用比例距离。举例说明：
+- `使用百分比` As can be seen from the above discussion, the `Relation` is always maintaining a set distance, which is the absolute distance, which is the distance of the pixel. Sometimes we need a proportional distance. FairyGUI provides such a feature that you can use proportional distance when setting up `Relation`s. For example:
 
 ![](../../images/20170802235057.png)
 
-笑脸图标增加了一个到容器组件的“左->中”关联，并勾选”使用百分比“。容器组件的宽度是200像素，现在笑脸图标的x坐标是50像素。也就是说，问号图标在容器组件的1/4位置，与容器组件的中心距离也是1/4的宽度。
+The smiley icon adds a `Left->Medium` `Relation` to the container-component and checks `Use Percentage`. The container-component's width is 200 pixels, and the smiley icon's x coordinate is now 50 pixels. That is to say, the question-mark icon is at the 1/4 position of the container assembly, and the center distance from the container assembly is also 1/4 of the width.
 
 ![](../../images/20170802235256.png)
 
-现在把设计好的组件拖出来使用，上面的是原来的宽度，200像素，下面把组件的宽度拉长为400像素。可以看到，笑脸图标依照左->中的关联规则发生了位移，它现在所在的位置是100像素，仍然保持了与容器组件中心距离1/4的宽度。
+Now drag the designed-component out, the upper width is 200 pixels, and the component's width is extended to 400 pixels. As we can see, the smiley icon has been displaced according to the `Relation` rule in `Left->`, which is now at 100 pixels and still maintains a width of 1/4 of the center of the container assembly.
 
-现在我们对比一下不勾选”使用百分比“的结果。在200像素的原大小下，问号图标于容器组件中心的位置距离是50像素。当下面的组件宽度变大后，问号图标与容器组件中心的位置依然是50像素。
+Now let's compare the results of not using "Use Percentage". At the original size of 200 pixels, the position of the question-mark icon at the center of the container assembly is 50 pixels. When the (below) component's width increases, the question-mark icon's position and the center of the container-component is still 50 pixels.
 
 ![](../../images/20170802235356.png)
 
 ## Relation
 
-除了在编辑器设置关联外，有时候我们也需要动态添加关联。例如在一款页游中，一个动态添加到舞台的组件，希望舞台宽度改变时（比如浏览器窗口被玩家拖大拖小），组件依然保持在右侧位置，那么可以这样调用：
+In addition to setting the `Relation` in the editor, sometimes we also need to dynamically add `Relation`s; For example, in an onboarding component (something that's dynamically added to the Stage). When you want the Stage width to change (such as the browser window being dragged by the player), the component remains in the rightmost position:
 
 ```csharp
     aObject.AddRelation(GRoot.inst, RelationType.Right_Right);
 ```
 
-又例如，一个动态添加到舞台的组件始终保持满屏大小，可以这样调用
+Another example: a component that's dynamically added to the Stage always maintains a fullscreen size and can be called like this:
 
 ```csharp
     aObject.SetSize(GRoot.inst.width, GRoot.inst.height);
     aObject.AddRelation(GRoot.inst, RelationType.Size);
 ```
 
-RelationType.Size相当于RelationType.Width_Width和RelationType.Height_Height的组合。这里强调一下，使组件变为满屏大小这个操作必须由你完成，也就是上面代码中的SetSize调用。关联并不能完成这项任务，因为关联是不管元件当前的大小的，它只会在目标变化时保持两者大小的差别。
+`RelationType.Size` is equivalent to a combination of `RelationType.Width_Width` and `RelationType.Height_Height`. It's emphasized here that the operation of making the component fullscreen size must be done by you, which is called `SetSize` in the above code. `Relation` doesn't accomplish this task, because the `Relation` is regardless of the component's current size, it only keeps the difference between the two when the target changes.
 
-删除关联的方法是：
+The way to remove the `Relation` is:
 
 ```csharp
-    //删除某个关联
+    // Remove a relation
     aObject.RemoveRelation(targetObject, RelationType.Size);
 
-    //删除指向某个对象的所有关联
+    // Remove all relations for an Object
     aObject.relations.ClearFor(targetObject);
 ```
 
-## 实例解析
+## Instance Resolution
 
-**实例一**
+**Example 1**
 
-这是一个游戏的主界面，主界面在实际显示时通常需要调整大小到满屏，这就要求设计时考虑到界面大小会变化的情况。下图是主界面中各个单独部件布局的要求：
+This is the main interface of the game. The main interface usually needs to be resized to the fullscreen when it's actually displayed. This requires the design to take into account the change in interface size. The following figure shows the requirements for the layout of individual components in the main interface:
 
 ![](../../images/2016-01-11_164517.jpg)
 
-A：和容器组件“左右居中“关联
-B：和容器组件”右->右”关联
-C：和容器组件“右->右”，”底->底“关联
-D：和容器组件”底->底”，“左右居中%”关联
-E：和容器组件“底->底”关联
+A: Associated with the container component "centered left and right"
+B: Associate with container component `Right->Right`
+C: and container component `Right->Righ`, `Bottom->Bottom` association
+D: and container component `Bottom->Bottom`, "left and right centered %" association
+E: Associated with the container component `Bottom->Bottom`
 
-然后运行时把这个界面设置为满屏就可以了。
+Then set this interface to fullscreen at runtime:
 
 ```csharp
     aComponent.SetSize(GRoot.inst.width, GRoot.inst.height);
-    //当屏幕改变时仍然保持全屏。如果屏幕大小始终不变，则这句也可以忽略
+    // It remains fullscreen when the screen changes. If the screen size is always the same, this statement can also be ignored.
     aComoponet.AddRelation(GRoot.inst, RelationType.Size);
 ```
 
-**实例二**
+**Example 2**
 
-这是一个游戏的NPC信息界面，NPC的介绍文本是动态的，这里使用了自动高度的文本。下面的链接是一个列表。要求列表在文本内容变化时，自动上移或下移。我们只需要将列表“顶->底”关联到文即可。
+This is a game's NPC information interface. The NPC's intro text is dynamic, and automatic height text is used here. The link below is a list. The request list is automatically moved up or down when the text content changes. We only need to create a "Top->Bottom" `Relation` of the list to the text.
 
 ![](../../images/2016-01-10_105206.jpg)
 
-**实例三**
+**Example 3**
 
-这是一个游戏中金钱数量的显示，要求当数量变化时，货币图标和文本保持居中。
+This is a currency counter. It requires the currency icon and text to remain centered as the quantity changes.
 
 ![](../../images/2015-12-21_170726.png)
 
@@ -177,7 +177,7 @@ E：和容器组件“底->底”关联
 
 ![](../../images/2015-12-21_172639.png)
 
-首先，文本需要设置为自动宽度和高度，这样数量变化时，文本自动会增长。
-用到的关联有：
-文本：左右居中关联到容器组件
-图标：左->左关联到文本
+First, the text needs to be set to automatic width and height so that when the number changes, the text automatically grows.
+The `Relation`s used are:
+Text: Left-and-right-centered to the container-component
+Icon: `Left->Left` `Relation` to text

--- a/src/guide/editor/text.md
+++ b/src/guide/editor/text.md
@@ -4,134 +4,134 @@ type: guide_editor
 order: 60
 ---
 
-文本是FairyGUI的一种基础控件。
+Text is a basic FairyGUI control.
 
-## 动态字体
+## Dynamic Font
 
-动态字体(Dynamic Font)是指直接使用ttf字体渲染文字。ttf字体文件可能存在于系统中，也可能打包在游戏中。
+Dynamic Font refers to rendering text directly using TTF fonts. The TTF font file may exist in the system or it may be packaged in the game.
 
-FairyGUI编辑器运行的环境，与应用实际运行的环境是不相同的。比如你在PC上制作界面，最终界面可能运行在手机上。在编辑界面时，动态字体是使用FairyGUI使用编辑器所在的系统环境的字体，在运行时，则是由实际的运行环境，例如Android系统等提供的字体。设计时的字体可以与运行时的字体不同，但建议选取效果较为相近的。
+The environment in which the FairyGUI editor runs isn't the same as the environment in which the application actually runs. For example, if you make an interface on a PC, the final interface may run on your phone. When editing the interface, the dynamic font is the font of the system environment in which the editor is used by FairyGUI. At runtime, it's the font provided by the actual running environment, such as the Android system. The font at design time can be different from the font at runtime, but it's recommended to select similar effects.
 
-设置编辑器使用的字体可以在项目属性里设置。运行时的字体则需要由代码设置：
+The font used by the setup editor can be set in the project properties. Runtime fonts need to be set by code:
 
 ```csharp
-    //Droid Sans Fallback是安卓上支持中文的默认字体
-    UIConfig.defaultFont = 'Droid Sans Fallback'; 
+    // Roboto is the default font for Android 4.0 onwards
+    UIConfig.defaultFont = "Roboto";
 ```
 
-设置运行时使用的字体需保证该字体在目标平台上也存在，否则达不到想要的效果。如果你想打包字体到目标平台，那么需要查询引擎提供的支持，比如Unity，可以这样做：[../unity/font.html](../unity/font.html "使用字体")
+Set the font used in the runtime to ensure that the font also exists on the target platform, otherwise the desired effect won't be achieved. If you want to package fonts to the target platform, you need the support provided by the query engine, such as Unity, you can do this.:[../unity/font.html](../unity/font.html "Use Font")
 
-如果要在编辑器里使用ttf字体，请双击ttf文件，确认安装到系统，这样重启编辑器后就可以在字体列表里看到这种字体了。
+If you want to use the TTF font in the editor, double-click the TTF file to confirm the installation to the system, so you can see the font in the font list after restarting the editor.
 
-## 位图字体
+## Bitmap Font
 
-在游戏中经常有这样的设计：一些表达特别元素的字符，使用了图片来制作，例如：
+There are often such designs in games: some characters that express special elements are made using pictures, for example:
 
 ![](../../images/20170801102632.png)
 
-FairyGUI编辑器支持位图字体。首先，我们创建一种字体。点击菜单“编辑”->“创建位图字体”，然后，弹出了字体编辑窗口，我们从资源库里把制作好的数字图片拖入到窗口，并设置每个图片对应的字符，点击保存，这样我们的字体就设置好了。如果要修改每个字符对应的图片，将图片重新拖入即可。
+The FairyGUI editor supports bitmap fonts. First, let's create a font. Click the menu "Edit" -> "Create Bitmap Font", then pop up the font editing window, we drag the created digital image from the resource library into the window, and set the characters corresponding to each image, click Save, This way our fonts are set. If you want to modify the picture corresponding to each character, drag the picture back in.
 
-使用图片代替字符的办法，对于少量文本，这是非常方便的，但如果需要嵌入成百上千字，为每个字制作为图片，然后再每个设置对应字符，这工作量就有点大了。FairyGUI编辑器支持外部的位图字体制作工具BMFont、ShoeBox等，这些工具的使用方法请自行参考网络资料。使用外部工具最后会导出一个fnt文件**（注意1：文件格式应该选择fnt格式，不支持xml或者json）**，在编辑器点击导入素材，然后选择这个fnt文件，就可以把字体导入到编辑器里了。
+The use of pictures instead of characters is very convenient for a small amount of text, but if you need to embed hundreds of words, make a picture for each word, and then set the corresponding characters for each, this workload is a bit much. FairyGUI editor supports external bitmap font creation tools such as BMFont, ShoeBox, etc. Please refer to the Internet for the use of these tools. Finally, an external fnt file will be exported using an external tool.**（Note 1: The file format should be in fnt format, not xml or json）**，You can import the font into the editor by clicking `Import Material` in the editor and selecting this fnt file.
 
-以下是推荐的BMFont导出设置：
+The following are the recommended BMFont export settings:
 
 ![](../../images/20170801103821.png)
 
-以下介绍位图字体设置界面的功能：
+The following describes the function of the bitmap font setting interface:
 
 ![](../../images/20170801102803.png)
 
-- `图片` 资源库里一张图片的名字。如果是由BMFont导入的字体，则此栏为空。
+- `Image` The name of an image in the repository. If it's a font imported by BMFont, this field is empty.
 
-- `字符` 该图片对应的字符。
+- `Character` The character corresponding to the picture.
 
-- `偏移X` 在水平方向上该字符的偏移。
+- `OffsetX` The offset of the character in the horizontal direction.
 
-- `偏移Y` 在垂直方向上该字符的偏移。负数表示字符上移，整数表示字符下移，但因为文字排版都是基线对齐，下移的结果可能是整行都发生下移。
+- `OffsetY` The offset of this character in the vertical direction. Negative numbers indicate that the characters move up, and integers indicate that the characters move down, but because the text layout is baseline alignment, the result of the down shift may be that the entire line moves down.
 
-- `占位` 一般来说，一个字符的水平占位宽度是由字符图片的宽度决定的。如果这里的数值不为0，则使用该值作为字符的水平占位宽度。
+- `XAdvance` 一In general, the horizontal footprint of a character is determined by the width of the character picture. If the value here isn't 0, then this value is used as the horizontal footprint of the character.
 
-- `字体大小` 位图字体的字号。在勾选“允许动态改变字号”后有效。
+- `Font Size` The font size of the bitmap font. It's valid after checking "Dynamic Size".
 
-- `默认占位` 统一设置所有字符的默认水平占位宽度。
+- `XAdvance` Unify the default horizontal footprint of all characters.
 
-- `允许动态改变字号` 勾选后，使用这个字体的文本可以设置字体大小使字符图片缩放。例如，先设置位图字体的“字体大小”为12，然后文本设置里设置字号为24，那么最终位图字体将放大一倍显示。如果这里不勾选，那么无论文本设置里字号为多少，位图字体都保持原样，不进行缩放。
+- `Dynamic Size` When checked, the text of this font can be used to set the font size to scale the character image. For example, first set the "font size" of the bitmap font to 12, and then set the font size to 24 in the text settings, then the final bitmap font will be doubled. If it isn't checked here, the bitmap font will remain the same regardless of the font size in the text settings, without scaling.
 
-- `允许动态改变颜色` 勾选后，使用这个字体的文本可以设置字符图片的颜色。这个改变颜色类似于改变图片元件颜色的功能。*（注：Egret、Laya版本目前不支持该特性）。* 如果不勾选，那么无论文本设置里文本的颜色是什么，位图字体都保持原来的颜色。
+- `Allow Tint` When checked, the text of the font can be used to set the color of the character image. This color change is similar to the function of changing the color of a picture element. *(Note: Egret, Laya version doesn't currently support this feature).* If unchecked, the bitmap font will remain the same color regardless of the color of the text in the text settings.
 
-- `纹理集` 如果字体是从BMFont导入的，那么字符图片都在一张贴图上，这里对应的是贴图资源。仅作展示，不可修改。如果你要设置该字体最终发布到哪张纹理集上，那么应该进入这个贴图图片的设置窗口设置。
+- `Atlas` If the font is imported from BMFont, then the character image is on a texture, which corresponds to the texture resource. For display purposes only, it cannot be modified. If you want to set which atlas the font will eventually be published to, you should enter the settings window settings for this texture image.
 
-## 实例属性
+## Instance Attributes
 
-点击主工具栏中的![](../../images/20170801092548.png)按钮，生成一个文本元件。
+Click on the main toolbar![](../../images/20170801092548.png)Button to generate a text component.
 
 ![](../../images/20180705091908.png)
 
-- `文本` 设置文本内容。当需要换行时，在编辑器里可以**直接按回车**。用代码赋值时需要换行可以用“\n”。
+- `Text` Set the text content. When you need to wrap, you can do it in the editor. **Press enter directly**. You can use "\n" when you need to change lines with code assignment.
 
-- `字体` 设置文字使用的字体。你不需要每个文本设置一次字体。在项目属性里可以设置项目中所有文本默认使用的字体。运行时则通过UIConfig.defaultFont统一设置。如果需要使用位图字体，可以从资源库中把字体资源拖动到这里。如果使用TTF字体，那么你需要将字体安装到操作系统，然后再在这里输入字体名称，或者点击旁边的A按钮进行选择。
+- `Font` Set the font used for the text. You don't need to set the font once for each text. In the project properties, you can set the default font used for all text in the project. The runtime is uniformly set by UIConfig.defaultFont. If you need to use bitmap fonts, drag font resources from the repository to here. If you use TTF fonts, then you need to install the fonts into the operating system, then enter the font name here, or click the `A` button next to it.
 
-- `字体大小` 设置文字使用的字号。如果使用的是位图字体，你需要对位图字体设置“允许动态改变字号”，这里的选项才有效。
+- `FontSize` Set the font size used for text. If you're using a bitmap font, you need to set the `"Allow dynamic change of font size"` for the bitmap font. The options here are valid.
 
-- `颜色` 设置文字颜色。如果使用的是位图字体，你需要对位图字体设置“允许动态改变颜色”，这里的选项才有效。
+- `Color` Set the text color. If you're using a bitmap font, you need to set the "Allow dynamic color change" setting for the bitmap font. The options here are valid.
 
-- `行距` 每行的像素间距。
+- `LineGap` The pixel pitch of each line.
 
-- `字距` 每个字符的像素间距。*（部分引擎不支持）*
+- `CharGap` The pixel pitch of each character. *（Some engines don't support）*
 
-- `自动大小` 
-  - `自动宽度和高度` 文本不会自动换行，宽度和高度都增长到容纳全部文本。
-  - `自动高度` 文本使用固定宽度排版，到达宽度后自动换行，高度增长到容纳全部文本。
-  - `自动收缩` 文本使用固定宽度排版，到达宽度后文本自动缩小，使所有文本依然全部显示。如果内容宽度小于文本宽度，则不做任何处理。**大部分情况下使用这个功能都需要同时勾上单行** *(位图字体要在字体属性里勾选'允许改变字号'才能使用自动收缩特性)*
-  - `无` 文本使用固定宽度和高度排版，不会自动换行。超出文本框范围的被剪裁。*（Laya、Egret、Unity平台没有开启此剪裁功能，也就是超出范围的依然会显示）*
+- `AutoSize`
+  - `Automatic Width and Height` text doesn't wrap automatically, width and height are increased to accommodate all text.
+  - `Auto Height` text uses a fixed width layout, automatically wraps after reaching the width, and grows to accommodate all text.
+  - `Shrink` The text is fixed-width formatted, and the text is automatically shrunken when the width is reached, so that all text is still displayed. If the content width is less than the text width, no processing is done. **In most cases, you need to hook a single line at the same time.** *(The bitmap font should be checked by 'Allow change of font size' in the font properties to use the auto-shrink feature.)*
+  - `None` Text is formatted with fixed width and height and doesn't wrap automatically. Clipped beyond the scope of the text box. *（This clipping function isn't enabled on Laya, Egret, and Unity platforms, that is, it will still be displayed when it's out of range.）*
 
-- `对齐` 设置文本的对齐。
+- `Align` Sets the alignment of the text.
 
-- `粗体` 设置文本为粗体。
+- `Bold` Set the text to bold.
 
-- `斜体` 设置文本为斜体。
+- `Italic` Set the text to italic.
 
-- `下划线` 设置文本为下划线。*（Laya平台不支持下划线）*
+- `Underline` Set the text to underline. *(Laya platform doesn't support underline)*
 
-- `单行` 设置文本为单行。单行文本不会自动换行，换行符也被忽略。
+- `Single Line` Set the text to a single line. Single-line text doesn't wrap automatically, and line breaks are ignored.
 
-- `描边` 设置文本的描边效果。描边效果在各个引擎实现方式不相同：
-  - AS3/Starling 使用滤镜的方式实现；
-  - Egret/Laya 使用H5引擎自身提供的功能；
-  - Unity 使用额外的Mesh模拟描边效果。一般一个字符的Mesh含有4个顶点（两个三角形），使用描边效果后则增加到20个顶点（十个三角形）。
+- `Stroke` Sets the stroke effect of the text. The stroke effect is different in each engine implementation:
+  - AS3/Starling is implemented using filters;
+  - Egret/Laya uses the features provided by the H5 engine itself;
+  - Unity uses an extra Mesh to simulate the stroke effect. Generally, a character's Mesh contains 4 vertices (two triangles), and after the stroke effect is added to 20 vertices (ten triangles).
 
-- `投影` 设置文本的投影效果。投影效果可以看做是简化的描边效果，描边是所有方向，投影只有一个方向。
+- `Shadow` Sets the shadow effect on the text. The shadow effect can be seen as a simplified stroke effect: the stroke is in all directions, and the shadow effect has only one direction.
 
-- `允许使用UBB语法` 设置文本支持UBB语法。使用UBB语法可以使单个文本包含多种样式，例如字体大小，颜色等。请参考[UBB语法](#UBB语法)。*（Laya/Cocos2dx版本不支持普通文本里包含多种样式，如果有这个需求，请改用富文本）*
+- `Allow UBB syntax` to set text to support UBB syntax. UBB syntax can be used to make a single text contain multiple styles, such as font size, color, and more. Please refer to [UBB Syntax](#UBBSyntax). *(Laya/Cocos2dx version doesn't support multiple styles in plain text. If you have this requirement, please use rich text instead.)*
 
-- `发布时清除文本` 表示文本只用作编辑器预览用途，发布时将会自动清除。
+- `Clear text when publishing` indicates that the text is only used for editor preview purposes and will be automatically cleared when published.
 
-- `允许使用模板` 勾选后，文本可以使用{count=100}这样的语法表达一个文本参数。请参考[文本模板](#文本模板)。
+- `Allow the use of templates` When checked, the text can express a text parameter using the syntax {count=100}. Please refer to [Text Template](#TextTemplate).
 
-- `输入` 设置文本用于输入。勾选后，点击选项旁边的![](../../images/20170801144514.png)按钮弹出输入类型文本的详细设置：
+- `Enter` Set the text for input. After checking, click the ![](../../images/20170801144514.png) button next to the option to pop up the detailed settings for the input type text:
 
 <center>
 ![](../../images/20170801144624.png)
 </center>
 
-- `最大长度` 允许输入的最大字符数量。0表示不限制。
+- `Max Chars` The maximum number of characters allowed to be entered. 0 means no limit.
 
-- `密码` 勾选后，输入的字符将显示成“*”号。
+- `Password` When checked, the entered characters will be displayed as " * ".
 
-- `输入限制` 限制用户输入的字符。一般只用在PC上。这里，不同平台的语法不一致。
+- `Restrict` Limit the characters entered by the user. Generally only used on PC. Here, the syntax of different platforms is inconsistent.
   - `AS3/Starling` 参考资料 [TextField.restrict](http://help.adobe.com/zh_CN/FlashPlatform/reference/actionscript/3/flash/text/TextField.html#restrict)。
   - `Egret` 参考资料 [TextField.restrict](http://developer.egret.com/cn/apidoc/index/name/egret.TextField#restrict)。
   - `Laya` 参考资料 [Input.restrict](https://layaair.ldc.layabox.com/api/?category=Core&class=laya.display.Input#restrict)。
-  - `Unity` 参考资料 [正则表达式语法](https://msdn.microsoft.com/zh-cn/library/az24scfc.aspx)。例如限制只能输入数字的表达式是：“[0-9]”。
+  - `Unity` 参考资料 [正则表达式语法](https://msdn.microsoft.com/zh-cn/library/az24scfc.aspx)。例如限制只能输入数字的表达式是:“[0-9]”。
 
-- `键盘类型` 设置在手机上输入时，弹出的手机键盘的类型。
+- `KeyBoardType` Set the type of phone keyboard that pops up when you type on your phone.
 
-- `提示文字` 设置输入文本内容为空时的显示内容，一般用来提示用户这里应该输入什么。这个提示文字可以设置单独的颜色或其他样式，方法是使用UBB语法（不需要文本勾选UBB），例如“[color=#CCCCCC]提示文字[/color]”。*（Egret和Laya版本不支持提示文字使用UBB语法，也就是不能指定提示文字的颜色）*
+- `Prompt Text` Set the display content when the input text content is empty, generally used to prompt the user what should be entered here. This prompt text can be set to a separate color or other style by using the UBB syntax (no need to check the UBB text), such as "[color=#CCCCCC]tip text[/color]" *（Egret and Laya versions don't support prompt text using UBB syntax, that is, you cannot specify the color of the prompt text.）*
 
 
 ## GTextField
 
-文本支持动态创建，例如：
+Text supports dynamic creation, for example:
 
 ```csharp
     GTextField aTextField = new GTextField();
@@ -139,162 +139,162 @@ FairyGUI编辑器支持位图字体。首先，我们创建一种字体。点击
     aTextField.text = "Hello World";
 ```
 
-动态改变文本的样式（字体大小、颜色等），在不同的平台，方式略有差别：
+Dynamically change the style of the text (font size, color, etc.), on different platforms, in a slightly different way:
 
 ```csharp
-    //Unity/Cry
+    // Unity/Cry
     TextFormat tf = aTextField.textFormat;
     tf.color = ...;
     tf.size = ...;
     aTextField.textFormat = tf;
 
-    //Cocos2dx
+    // Cocos2dx
     TextFormat* tf = aTextField->getTextFormat();
     tf->color = ...;
     tf->size  ...;
     aTextField->applyTextFormat();
 
-    //其他平台
+    // Other platforms
     aTextField.color = ...;
     aTextField.fontSize = ...;
 ```
 
-如果要设置文本的字体为位图字体，字体名称直接使用字体的url就可以了，例如‘ui://包名/字体名’。
+If you want to set the font of the text to be a bitmap font, the font name can be used directly by the font url, such as "ui://package name/font name".
 
 ## GTextInput
 
-如果文本勾选为“输入”，则运行中的实例对象为GTextInput。
+If the text is checked as "input", the running instance object is `GTextInput`.
 
-可以通过UIConfig.inputHighlightColor和UIConfig.inputCaretSize修改光标的颜色和大小。注意，输入光标的大小会自动根据屏幕缩放选择最合适的宽度，一般情况下你不需要修改。
+The color and size of the cursor can be modified via `UIConfig.inputHighlightColor` and `UIConfig.inputCaretSize`. Note that the size of the input cursor will automatically select the most appropriate width according to the screen zoom, generally you don't need to modify it.
 
-输入文本在文本改变时有通知事件：
+Input text has a notification event when the text changes:
 
 ```csharp
-    //Unity/Cry
+    // Unity/Cry
     aTextInput.onChanged.Add(onChanged);
 
-    //AS3
+    // AS3
     aTextInput.addEventListener(Event.CHANGE, onChanged);
 
-    //Egret
+    // Egret
     aTextInput.addEventListener(Event.CHANGE, this.onChanged, this);
 
-    //Laya
+    // Laya
     aTextInput.on(laya.events.Event.INPUT, this, this.onChanged);
 ```
 
-在获得焦点和失去焦点时有通知事件：
+Notification event when getting focus and losing focus:
 
 ```csharp
-    //Unity
+    // Unity
     aTextInput.onFocusIn.Add(onFocusIn);
     aTextInput.onFocusOut.Add(onFocusOut);
 
-    //AS3
+    // AS3
     aTextInput.addEventListener(FocusEvent.FOCUS_IN, onFocusIn);
     aTextInput.addEventListener(FocusEvent.FOCUS_OUT, onFocusOut);
 
-    //Egret
+    // Egret
     aTextInput.addEventListener(FocusEvent.FOCUS_IN, this.onFocusIn, this);
     aTextInput.addEventListener(FocusEvent.FOCUS_OUT, this.onFocusOut, this);
 
-    //Laya
+    // Laya
     aTextInput.on(laya.events.Event.FOCUS, this, this.onFocusIn);
     aTextInput.on(laya.events.Event.BLUR, this, this.onFocusOut);
 ```
 
-如果要主动设置焦点，可以用
+To set the focus actively:
 
 ```csharp
     aTextInput.RequestFocus();
 ```
 
-如果输入文本设置了单行，则当用户按回车键时会派发一个事件（注意，仅在PC上有效。在手机上的键盘按Done不属于支持范围内，引擎一般没有提供和手机键盘交互的接口）：
+If the input text is set to a single line, an event will be dispatched when the user presses the Enter key (note that it's only valid on the PC. The keyboard on the phone isn't supported by Done, the engine generally doesn't provide interaction with the phone keyboard. interface):
 
 ```csharp
-    //Unity
+    // Unity
     aTextInput.onSubmit.Add(onSubmit);
 ```
 
-## UBB语法
+## UBB Syntax
 
-FairyGUI支持的UBB语法有：
+The UBB syntax supported by FairyGUI has:
 
-- `[img]image_url[/img]` 显示一个图片。这里的image_url可以是"ui://包名/图片名"的内部url格式，也可以是一个外部资源的url。图片最终是通过GLoader显示的，支持外部资源的能力可以参阅GLoader的文档。在这里，你无法设置图片大小。如果需要需要设置图片大小，改用HTML语法。
+- `[img]image_url[/img]` Display an image. The image_url here can be the internal url format of "ui://package name/image name" or the url of an external resource. The image is ultimately displayed via GLoader, and the ability to support external resources can be found in the GLoader documentation. Here you can't set the image size. If you need to set the image size, use HTML syntax instead.
 
-- `[url=link_href]text[/url]` 显示一个超级链接。其中link_href可以在链接点击后触发的事件里获得。
+- `[url=link_href]text[/url]` Show a hyperlink. The link_href can be obtained in the event triggered by the link click.
 
-- `[b]text[/b]` 设置文本为粗体。
+- `[b]text[/b]` Set the text to bold
 
-- `[i]text[/i]` 设置文件为斜体。
+- `[i]text[/i]` The settings file is italic.
 
-- `[u]text[/u]` 设置文本为下划线。
+- `[u]text[/u]` Set the text to be underlined.
 
-- `[sup]text[/sup]` 设置文本为上标。*（仅Unity平台支持，且在编辑器暂时无法预览）*
+- `[sup]text[/sup]` Set the text to superscript. *(Only supported by Unity platform, and cannot be previewed temporarily in the editor)*
 
-- `[sub]text[/sub]` 设置文本为下标。*（仅Unity平台支持，且在编辑器暂时无法预览）*
+- `[sub]text[/sub]` Set the text to a subscript. *(Only supported by Unity platform, and cannot be previewed temporarily in the editor)*
 
-- `[color=#FFFFFF]text[/color]` 设置文本颜色。注意一定要用十六进制颜色代码，像red、blue这种颜色名称是不支持的。使用color语法还可以设置文本颜色为渐变色*（仅Unity平台支持，且在编辑器暂时无法预览）*，例如：
+- `[color=#FFFFFF]text[/color]` Set the text color. Be sure to use hexadecimal color code. Color names like red and blue aren't supported. You can also set the text color to a gradient color using the color syntax *(only supported by the Unity platform and temporarily not previewable in the editor)*, for example:
 
 ```csharp
-    //指定两个颜色表示上下过渡
+    // Specify two colors to indicate the up and down transition
     [color=#FFFFFF,#000000]文字[/color]
 
-    //指定四个颜色可以做左右过渡或者双方向过渡
+    // Specify four colors to make a left or right transition or a two-way transition
     [color=#FFFFFF,#CCCCCC,#000000,#FFFF00]文字[/color]
 ```
 
-- `[font=font_face]text[/font]` 设置文本的字体。
+- `[font=font_face]text[/font]` Set the font for the text.
 
-- `[size=10]text[/size]` 设置文本的字体大小。
+- `[size=10]text[/size]` Set the font size of the text.
 
-- `[align=left/center/right]text[/align]` 设置文本的水平对齐。*（仅Unity平台支持，且在编辑器暂时无法预览）*
+- `[align=left/center/right]text[/align]` Set the horizontal alignment of the text. *(Only supported by Unity platform, and cannot be previewed temporarily in the editor)*
 
-标签之间支持嵌套，但不支持交叉嵌套。例如：
+Nesting is supported between tags, but cross-nesting isn't supported. E.g:
 
 ```csharp
-    //允许
+    // Allowed
     [color=#FFFFFF][size=20]text[/size][/color]
 
-    //不允许
+    // Not allowed
     [color=#FFFFFF][size=20]text[/color][/size]
 ```
 
-对不支持的标签，例如“[tag]text[/tag]”，FairyGUI不做解析，这部分内容原样输出。当“[”字符要用于非UBB语法时，可以使用"\\["这样的方式转义，注意，在编辑器输入时是直接输入"\\"即可，在代码里需要用"\\\\"这样才能表达反斜杠。另外，只需转义"["，不需要转义"]"。
+For unsupported tags, such as "[tag]text[/tag]", FairyGUI doesn't parse, and this part of the content is output as it is. When the "[" character is to be used in non-UBB syntax, you can use "\\[" to escape. Note that you can directly enter "\\" when typing in the editor. You need to use "\" in the code. \\\" This way you can express backslashes. In addition, just escaping "[", no need to escape"]".
 
-**普通文本不支持语法中的img、url标签，因为普通文本是不可以图文混排的。要支持图文混排，改为使用富文本。**
- 
-FairyGUI也提供了扩展UBB解析器的方法。继承UBBParser类，注册自己的TagHandler即可。具体实现方法请阅读UBBParser的源码或参考demo。
+**Ordinary text doesn't support the img and url tags in the grammar, because ordinary text isn't arbitrarily arranged. To support graphics and text, use RichText instead.**
 
-## 文本模板
+FairyGUI also provides a way to extend the UBB parser. Inherit the `UBBParser` class and register your own `TagHandler`. Please refer to the `UBBParser` source code or reference demo for specific implementation methods.
 
-使用文本模板可以更灵活的动态调整文本输出。例如，如果需要显示“我的元宝：100金200银”，那么常见的制作方式有：
-1. 使用一个文本控件显示，那么运行时程序员要改变数值时只能整个文本重新打一遍，这无疑是一个冗余的工作量，且不利于美术和程序解耦。
-2. 使用四个文本控件显示，那么运行时程序员只需要改变显示数值的文本控件即可，但美术的工作量增大。
+## Text Template
 
-使用文本模板功能，可以轻松解决这种需求。只需要在编辑器放置一个文本控件，文本为“我的元宝：{jin=100}金{yin=200}银”，然后勾选“使用文本模板”即可。这样在编辑器中显示依然是“我的元宝：100金200银”，运行时程序员只需要执行以下的代码就可以更新数值：
+Use text templates to more flexibly adjust text output dynamically. For example, if you need to display "My Ingot: 100 Gold 200 Silver", then the common methods are:
+1. Using a text control display, then the runtime programmer can update the entire text when changing the value. This is undoubtedly a redundant workload and isn't conducive to art and program decoupling.
+2. Using four text controls to display, then the runtime programmer only needs to change the text control that displays the value, but the artwork is increased.
+
+This requirement can be easily satisfied using the text template feature. Just put a text control in the editor, the text is "My Ingot: {jin=100}金{yin=200}Silver", then check "Use Text Template". This way the display in the editor is still "my ingot: 100 gold 200 silver", the runtime programmer only needs to execute the following code to update the value:
 
 ```csharp
     aTextField.SetVar("jin", "500").SetVar("yin", "500").FlushVars();
 ```
 
-也可以批量设置：
+They can also be set in batches:
 
 ```csharp
     Dictionary<string, string> values;
     values["jin"] = "500";
     values["yin"] = "500";
-    //注意，这种方式不需要再调用FlushVars
+    // Note that this method doesn't need to call FlushVars again.
     aTextField.templateVars = values;
 ```
 
-如果运行时要动态启用文本模板功能，不需要设置什么开关，只需要直接调用SetVar即可。
-如果运行时要动态关闭文本模板功能，只需要把templateVars设置为null即可，即：
+If you want to dynamically enable the text template function at runtime, you don't need to set any switches, just call `SetVar` directly.
+If you want to dynamically turn off the text template function at runtime, just set `templateVars` to null, ie:
 
 ```csharp
    aTextField.templateVars = null;
 ```
 
-当“{”字符不是用于模板时，可以使用"\\{"这样的方式转义，注意，在编辑器输入时是直接输入"\\"即可，在代码里需要用"\\\\"这样才能表达反斜杠。另外，只需转义"{"，不需要转义"}"。
+When the "{" character isn't used for the template, you can use the "\\{" method to escape. Note that you can directly enter "\\" when entering the editor. You need to use "\\\" in the code. \"This way to express a backslash. In addition, just escaping "{", you don't need to escape "}".
 
-文本模板优先于UBB解析，所以模板也可以在UBB中使用，例如文本为："这个是可以变色的[color={color=#FF0000}]文本[/color]"，可以方便的实现动态更改部分文本颜色的需求。
+The text template takes precedence over UBB parsing, so the template can also be used in UBB. For example, the text is: "This is a color [color={color=#FF0000}] text[/color]", which can be easily changed dynamically. The need for text color.

--- a/src/guide/editor/upgrade_binary_format.md
+++ b/src/guide/editor/upgrade_binary_format.md
@@ -4,49 +4,50 @@ type: guide_editor
 order: 230
 ---
 
-编辑器从3.9.0版本起，支持了新的发布格式，即二进制格式（下面简称新格式）*(注：AS3/Starling/Haxe版本不会提供新格式的支持，请忽略本文)*。和以往使用的XML格式（下面简称旧格式）不同，二进制格式更加紧凑，解析时更快，而且占用的内存和产生的内存垃圾更少。
-**(注意：只是指发布后的格式，编辑器里的文件格式不会有任何改变）**
+The editor has supported the new release format since the 3.9.0 release, which is the binary format (hereafter referred to as the new format) *(Note: AS3/Starling/Haxe version won't provide support for the new format, please ignore this article)*. Unlike the XML format used in the past (hereafter referred to as the old format), the binary format is more compact, faster to parse, and uses less memory.
 
-新格式对比旧格式，在不同场合下可以获得的提升为：
-- `AddPackage`： GC最大可降低90% CPU耗时最大可降低80%
-- `CreateObject`：GC最大可降低约15% CPU耗时最大可降低20%
+**(Note: just refers to the format after the release, the file format in the editor won't change)**
 
-对于Unity引擎，使用新格式需要使用FairyGUI-Unity 3.0或以上版本，其他引擎尽量更新到最近的库。编辑器更新到3.9.0版本后，在发布对话框里的全局设置里，勾选“使用二进制格式”。
+The new format compares to the old format and the upgrades that can be obtained in different situations are:
+- `AddPackage`: GC can be reduced by up to 90%, CPU can be reduced by up to 80%
+- `CreateObject`: GC can be reduced by up to 15%, CPU can be reduced by up to 20%
 
-**文件命名**
+For the Unity engine, using the new format requires FairyGUI-Unity 3.0 or above, and other engines try to update to the nearest library. After the editor is updated to version 3.9.0, in the global settings in the release dialog, check `"Use Binary Format"`.
 
-新格式的文件命名与旧格式不同。旧格式的文件名中有使用“@”作为连接字符，由于有不少用户反映这个字符在某些场合下不允许使用，所以新格式改为使用“_”字符。在旧格式中，Unity的描述文件名为“xxx.bytes",新格式中，更改为“xxx_fui.bytes"，这是为了可以更快的识别出包文件。新格式只有一个描述文件和一个或多个贴图和声音文件，不会再生成单独的sprites文件。
+**File Naming**
 
-支持新格式的SDK不再支持读取旧格式的文件，同样，旧的SDK也无法识别新格式的文件，无法无缝切换，你需要做出抉择。
+The file name of the new format is different from the old format. The "@" is used as the connection character in the file name of the old format. Since many users reflect that this character isn't allowed in some cases, the new format is changed to use the "_" character. In the old format, Unity's description file name is `"xxx.bytes"`, and in the new format, it is changed to `"xxx_fui.bytes"`, in order to recognize the package file more quickly. The new format has only one description file and one or more texture and sound files, and no separate sprites are generated.
 
-**UI包管理**
+SDKs that support the new format no longer support reading files in the old format. Similarly, the old SDK doesn't recognize files in the new format and cannot be seamlessly switched. You need to make a decision.
 
-使用新格式后，UI包的管理策略有改变，主要为：
-1. 现在AddPackage时不会像以前那样把全部资源（贴图、声音）一次性载入，而是用到再载入。如果你需要全部载入，调用`UIPackage.LoadAllAssets`。
+**UI Package Management**
 
-2. 如果UIPackage是从AssetBundle中载入的，在RemovePackage时AssetBundle才会被Unload(true)。如果你确认所有资源都已经载入了（例如调用了LoadAllAssets），也可以自行卸载AssetBundle。
+After using the new format, the management strategy of the UI package has changed, mainly:
+1. Now `AddPackage` doesn't load all the resources (maps, sounds) in one go, but uses them again. If you need to load all, call `UIPackage.LoadAllAssets`.
 
-3. 调用`UIPackage.UnloadAssets`可以只释放UI包的资源，而不移除包，也不需要卸载从UI包中创建的UI界面（这些界面你仍然可以调用显示，不会报错，但图片显示空白）。当包需要恢复使用时，调用`UIPackage.ReloadAssets`恢复资源，那些从这个UI包创建的UI界面能够自动恢复正常显示。如果包是从AssetBundle载入的，那么在UnloadAssets时AssetBundle会被Unload(true)，所以在ReloadAssets时，必须调用ReloadAssets一个带参数的重载并提供新的AssetBundle实例。
+2. If the `UIPackage` is loaded from the `AssetBundle`, the `AssetBundle` will be `Unload(true)` when the `RemovePackage` is used. If you confirm that all resources have been loaded (for example, `LoadAllAssets` is called), you can also uninstall the `AssetBundle` yourself.
 
-4. Egret版本目前不支持Unload和Reload；Laya版本支持Unload，但不需要调用Reload，贴图资源一旦用到就会自动Reload。
+3. Call `UIPackage.UnloadAssets` to release only the resources of the UI package without removing the package, and you don't need to uninstall the UI interface created from the UI package (these interfaces can still call the display, no error is reported, but the image is blank). When the package needs to be restored, call `UIPackage.ReloadAssets` to restore the resources. The UI interface created from this UI package can automatically restore the normal display. If the package is loaded from the `AssetBundle`, the `AssetBundle` will be Unload(true) in `UnloadAssets`, so in `ReloadAssets`, you must call `ReloadAssets` with a parameter overload and provide a new `AssetBundle` instance.
 
-5. 使用新格式后，UI包描述部分占用的内存急剧减少（只有几十KB~几百KB的规模），所以可以不用再管理包的装载卸载，而直接让UIPackage都常驻，再配合使用UnloadAssets和ReloadAssets就可以达到控制内存的效果了（当然这只是建议）。
+4. The Egret version doesn't currently support `Unload` and `Reload`; the Laya version supports `Unload`, but doesn't need to call `Reload`. Once the texture resource is used, it will automatically `Reload`.
 
-6. 在Unity编辑器中运行时，即使UI包没有放置在Resources下，现在也能够正常加载，路径用全路径即可，当然，打包APP后是不可能加载的，你需要用宏做区别。例如：
+5. After using the new format, the memory occupied by the UI package description is drastically reduced (only tens of KB instead of several hundred KB), so you can save the package, load, and unload without directly managing the `UIPackage`, and then use `UnloadAssets` and `ReloadAssets` to manage memory (of course this is only a suggestion).
+
+6. When running in the Unity editor, even if the UI package isn't placed under Resources, it can be loaded normally, and the path can be full path. Of course, it is impossible to load after packaging the APP. You need to use macros to make a difference. E.g:
   ```csharp
-    //编辑器环境下直接从文件路径中加载，方便测试，正式环境则使用AssetBundle
+    // Loaded directly from the file path in the editor environment for testing, the official environment uses `AssetBundle`
     #if UNITY_EDITOR
         UIPackage.AddPackage("Assets/SomePath/Package1");
     #else
         UIPackage.AddPackage(ab);
     #endif
   ```
-  同样，UIPanel也可以选择任意路径下的包，编辑器下都能够正常显示。运行时则需要保证包在UIPanel激活前加载好。
+  Similarly, `UIPanel` can also select packages in any path, and it can be displayed normally under the editor. The runtime needs to ensure that the package is loaded before the `UIPanel` is activated.
 
-**另外的一些接口改变**
+**Other API Changes**
 
-1. [Unity] UIConfig.buttonSound原来接受一个AudioClip对象，现在需要用NAudioClip，可以用直接用new NAudioClip(audioClip)包装。UIPacakge.GetItemAsset(声音item）现在返回的也是NAudioClip对象。
+1. [Unity] `UIConfig.buttonSound` originally accepted an `AudioClip` object, now you need to use `NAudioClip`, you can use the new `NAudioClip` (audioClip) package. `UIPacakge.GetItemAsset` (sound item) now returns the `NAudioClip` object.
 
-2. [Unity] UIPackage.AddPackage的接受AssetBundle参数的重载，不再提供unloadBundleAfterLoaded参数。AssetBundle也不会在AddPackage后立刻卸载。
+2. [Unity] `UIPackage.AddPackage` accepts the overload of the `AssetBundle` parameter and no longer provides the `unloadBundleAfterLoaded` parameter. `AssetBundle` won't be uninstalled immediately after `AddPackage`.
 
-3. 获取编辑器内在组件设计期设置的自定义数据，需要使用新加的API：GComponent.baseUserData；获取编辑器内对元件定义的自定义数据的方法则不变，仍然是GObject.data。
+3. To get the `Custom Data` set in the editor's built-in component design panel, you need to use the newly added API: `GComponent.baseUserData`; the method to get the custom data defined by the component in the editor remains unchanged: `GObject.data`.

--- a/src/guide/editor/window.md
+++ b/src/guide/editor/window.md
@@ -4,27 +4,27 @@ type: guide_editor
 order: 190
 ---
 
-窗口是组件的一种特殊扩展。编辑器内并没有窗口的概念，因为窗口可以设置任意组件作为它的显示内容。窗口=内容组件+窗口管理API。
+A window is a special extension of a component. **There is no concept of a window in the editor because the window can set any component as its display content.** `Window` = Content Component + Window Management API.
 
-## 设计窗口
+## Design Window
 
-窗口内容组件需要在编辑器编辑好。通常窗口会包括一个可用于拖动的标题栏，关闭按钮等。FairyGUI使用约定名称将一些常见的窗口功能和我们定义的组件关联起来。首先，窗口内容组件内需要放置一个名称为`frame`的组件，这个组件将作为窗口的背景，或者成为框架。这个组件的的扩展通常选择为“标签”。
+The window content component needs to be edited in the editor. Usually the window will include a title bar that can be used for dragging, a close button, and so on. FairyGUI uses convention names to associate some common window functions with the components we define. First, you need to place a component named `frame` inside the window content component, which will be the background of the window or become the frame. The extension of this component is usually chosen to be "tag".
 
 ![](../../images/20170807161046.png)
 
-这个frame组件的制作方式为：
+This frame component is made in the following ways:
 
-- `closeButton` 一个名称为closeButton的按钮将自动作为窗口的关闭按钮。
+- `closeButton` 一A button named `closeButton` will automatically be used as the window's close button.
 
-- `dragArea` 一个名称为dragArea的图形（类型设置为空白）将自动作为窗口的检测拖动区域，当用户在此区域内按住并拖动时，窗口随之被拖动。
+- `dragArea` 一A graphic named `dragArea` (with the type set to blank) will automatically be used as the detection drag area of the window. When the user presses and drags in this area, the window is dragged.
 
-- `contentArea` 一个名称为contentArea的图形（类型设置为空白）将作为窗口的主要内容区域，这个区域只用于ShowModalWait。当调用ShowModalWait时，窗口会被锁定，如果设定了contentArea，则只锁定contentArea指定的区域，否则锁定整个窗口。如果你希望窗口在modalWait状态下依然能够拖动和关闭，那么就不要让contentArea覆盖标题栏区域。
+- `contentArea` 一A graphic named `contentArea` (with the type set to blank) will be used as the main content area of the window, which is only used for `ShowModalWait`. When `ShowModalWait` is called, the window will be locked. If contentArea is set, only the area specified by `contentArea` will be locked, otherwise the entire window will be locked. If you want the window to still be dragged and closed in the modalWait state, then don't let the `contentArea` override the title bar area.
 
-注意以上的约定均为可选，是否含有组件frame，或者组件frame里是否含有约定的功能组件，并不会影响窗口的正常显示和关闭。
+Note that the above conventions are optional. Whether the component frame is included or whether the component frame contains the agreed function components does not affect the normal display and shutdown of the window.
 
-## 使用窗口
+## Use Window
 
-内容组件制作好后，运行时就可以使用以下的方式创建和使用窗口：
+Once the content component is created, the runtime can use the following methods to create and use the window:
 
 ```csharp
     Window win = new Window();
@@ -32,73 +32,72 @@ order: 190
     win.Show();
 ```
 
-另外，FairyGUI还提供了一套机制用于窗口动态创建。动态创建是指初始时仅指定窗口需要使用的资源，等窗口需要显示时才实际开始构建窗口的内容。首先需要在窗口的构造函数中调用`AddUISource`。这个方法需要一个`IUISource`类型的参数，而IUISource是一个接口，用户需要自行实现载入相关UI包的逻辑。当窗口第一次显示之前，IUISource的加载方法将会被调用，并等待载入完成后才返回执行`OnInit`，然后窗口才会显示。
+In addition, FairyGUI provides a mechanism for dynamic window creation. Dynamic creation means that only the resources that the window needs to be used are initially specified, and the contents of the window are actually started when the window needs to be displayed. First you need to call `AddUISource` in the window's constructor. This method requires a parameter of type `IUISource`, and `IUISource` is an interface, and the user needs to implement the logic of loading the relevant UI package. The IUISource's loading method will be called before the window is first displayed, and will wait until the loading is complete before returning to execute `OnInit`, and the window will be displayed.
 
-调用`Show`显示窗口的流程：
+Call `Show` to display the flow of the window:
 
 ![](../../images/ddd.png)
 
-如果你需要窗口显示时播放动画效果，那么覆盖`doShowAnimation`编写你的动画代码，并且在动画结束后调用onShown。
-覆盖`onShown`编写其他需要在窗口显示时处理的业务逻辑。
+If you need to play an animation when the window is displayed, override `doShowAnimation` to write your animation code and call `onShown` after the animation ends.
+Override `onShown` to write other business logic that needs to be processed when the window is displayed.
 
-调用`Hide`隐藏窗口的流程：
+Call `Hide` to hide the window:
 
 ![](../../images/ddd2.png)
 
-如果你需要窗口隐藏时播放动画效果，那么覆盖d`doHideAnimation`编写你的动画代码，并且在动画结束时调用`HideImmediately`（**注意不是直接调用onHide！**）。
-覆盖`onHide`编写其他需要在窗口隐藏时处理的业务逻辑。
+If you need to play an animation when the window is hidden, override `doHideAnimation` to write your animation code and call `HideImmediately` at the end of the animation.（**Note that this is instead of calling onHide directly!**)
+Override `onHide` to write other business logic that needs to be processed when the window is hidden.
 
 ## Window
 
-- `Show` 显示窗口。
+- `Show` Display window.
 
-- `Hide` 隐藏窗口。窗口并不会销毁，只是隐藏。
+- `Hide` Hide the window. The window will not be destroyed, just hidden.
 
-- `isShowing` 获取窗口是否显示。
+- `isShowing` Gets whether the window is displayed.
 
-- `modal` 设置窗口是否模态窗口。模态窗口将阻止用户点击任何模态窗口后面的内容。当模态窗口显示时，模态窗口背后可以自动覆盖一层灰色的颜色，这个颜色可以自定义：
+- `modal` Set whether the window is a modal window. The modal window will prevent the user from clicking on the content behind any modal window. When the modal window is displayed, the modal window can be automatically covered with a layer of gray color. This color can be customized:
 
 ```csharp
-    //Unity
+    // Unity
     UIConfig.modalLayerColor = new Color(0f, 0f, 0f, 0.4f);
-    
-    //AS3
+
+    // AS3
     UIConfig.modalLayerColor = 0x333333;
     UIConfig.modalLayerAlpha = 0.2;
 ```
 
-如果你不需要这个灰色效果，那么把透明度设置为0即可。
+If you don't need this gray effect, set the transparency to 0.
 
-- `ShowModalWait` 锁定窗口，不允许任何操作。锁定时可以显示一个提示，这个提示的资源由下面的设置指定：
+- `ShowModalWait` Lock the window and do not allow any action. A prompt can be displayed when locked, the resource of this prompt is specified by the following settings:
 
 ```csharp
-    UIConfig.windowModalWaiting = "ui://包名/组件名";
+    UIConfig.windowModalWaiting = "ui://PackageName/ComponentName";
 ```
 
-这个组件会调整和contentArea相同的大小。
+This component will adjust to the same size as the `contentArea`.
 
-- `CloseModalWait` 取消窗口的锁定。
+- `CloseModalWait` Cancel the lock of the window.
 
-**窗口自动排序**
+**Window Sorting**
 
-默认情况下，Window是具有点击自动排序功能的，也就是说，你点击一个窗口，系统会自动把窗口提到所有窗口的最前面，这也是所有窗口系统的规范。但你可以关闭这个功能：
+By default, `Window` has the function of automatic sorting by clicking, that is, when you click on a window, the system will automatically refer the window to the front of all windows, which is the specification of all window systems. But you can turn off this feature:
 
 ```csharp
     UIConfig.bringWindowToFrontOnClick = false;
 ```
 
-**窗口管理**
+**Window Management**
 
-GRoot里提供了一些窗口管理的常用API。
+GRoot provides some common APIs for window management.
 
-- `BringToFront` 把窗口提到所有窗口的最前面。
-- `CloseAllWindows` 隐藏所有窗口。注意不是销毁。
-- `CloseAllExceptModals` 隐藏所有非模态窗口。
-- `GetTopWindow` 返回当前显示在最上面的窗口。
-- `hasModalWindow` 当前是否有模态窗口在显示。
+- `BringToFront` Put the window to the front of all windows.
+- `CloseAllWindows` Hide all windows. Note that they are not destroyed.
+- `CloseAllExceptModals` Hide all non-modal windows.
+- `GetTopWindow` Returns the window currently displayed at the top.
+- `hasModalWindow` Is there a modal window currently displayed?
 
-**直接加组件到GRoot，和使用Window有什么区别？**
-GRoot是2D UI的根容器。当我们通过UIPackage.CreateObject创建出顶级UI界面后，将它添加到GRoot下。例如游戏的登录界面、主界面等，这类界面的特点是在游戏的底层，且比较固定。
+**What's the difference between directly adding components to GRoot and using Window？**
+`GRoot` is the root container of the 2D UI. When we create the top UI interface through `UIPackage.CreateObject`, add it to `GRoot`. For example, the login interface of the game, the main interface, etc., the characteristics of such interfaces are at the "bottom" layer of the game, and relatively fixed.
 
-Window的本质也是通过UIPackage.CreateObject动态创建的顶级UI界面，但它提供了常用的窗口特性，比如自动排序，显示/隐藏流程，模式窗口等。适用于游戏的对话框界面，例如人物状态、背包、商城之类。这类界面的特点是在游戏的上层，且切换频繁。
-
+The essence of `Window` is also the top-level UI interface dynamically created by `UIPackage.CreateObject`, but it provides common window features, such as automatic sorting, show/hide process, mode window, etc. A dialog interface for games, such as character stats, inventories, mailboxes, and the like. This type of interface is characterized by the "upper" layers of the game and is frequently switched.

--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -6,15 +6,15 @@ order: 0
 
 FairyGUI is a Cross Platform UI Editor & UI framework.
 
-By using FairyGUI Editor, you can build a variety of complex game interface without writing code or any configuration files. Support `Unity`、`Cocos2dx`、`Cry Engine`、 `MonoGame`、`Havok Vision/Project Anarchy`、`Egret`、`LayaAir`、`Haxe`、`Pixi`、`Flash`、`Starling`，`Corona`，and `Unreal`、`LibGDX`、`Three.js` in the future.<br>
+By using FairyGUI Editor, you can build a variety of complex game interface without writing code or any configuration files. Supports `Unity`、`Cocos2dx`、`Cry Engine`、 `MonoGame`、`Havok Vision/Project Anarchy`、`Egret`、`LayaAir`、`Haxe`、`Pixi`、`Flash`、`Starling`，`Corona`，and `Unreal`、`LibGDX`、`Three.js` in the future.<br>
 
 ## Features
 
 * WYSIWYG. Easy to use, and habits consistent with the Adobe series of software, planning and art designers can easily get started.
 
-* In the editor can be combined with a variety of complex UI components, no need to write code. No programmers need to extend the UI component.
+* The editor can be used to combine a variety of complex UI components; no need to write code. No programmers are needed to extend the UI component.
 
-* Support for translation, zoom, rotation, tilt, flip and other conventional 2D transform.
+* Support for translation, zoom, rotation, tilt, flip and other conventional 2D transforms.
 
 * Powerful text controls. Support for dynamic fonts, bitmap fonts, and external tools (such as BMFont, etc.) produced by the bitmap fonts, while supporting HTML syntax and UBB syntax to support complex graphics mixed. The input text supports the direct input of the IOS native expression. Support the font of the stroke effect, shadow effects, support for gradient text.
 
@@ -48,14 +48,14 @@ By using FairyGUI Editor, you can build a variety of complex game interface with
 
 * Support in the UI layer to insert any 3D objects, such as models, particles, skeleton animation, etc., automatically handle the rendering order.
 
-* Edit the use of decentralized material, published automatically packaged atlas. Support the definition of multiple Atlas, Unity version automatically supports the extraction of A channel compression.
+* Edit the use of decentralized material, published automatically packaged atlas. Supports the definition of multiple Atlas. Unity version automatically supports the extraction of A channel compression.
 
 * Multi-language switching support. You can switch UI language in real time.
 
-* Various resolution adaptive. A set of UIs for different resolution devices.
+* Various adaptive resolution modes. A set of UIs for different resolution devices.
 
 * Support for automatically generating code for editor components.
 
-* Provide plug-in mechanism, according to the needs of the project for the editor to add personality features.
+* Provides a plug-in mechanism, according to the needs of the project for the editor to add personality features.
 
-* Support design function, directly to the design shown in the background, easy to control the precise splicing.
+* Supports design functionality, with the design directly shown on the canvas. It's easy to control the precise splicing.

--- a/src/guide/sdk/cocos2dx.md
+++ b/src/guide/sdk/cocos2dx.md
@@ -4,29 +4,29 @@ type: guide_sdk
 order: 3
 ---
 
-## 运行Demo
+## Running the Demo
 
-1. 从GitHub Clone或者直接下载FairyGUI-cocos2dx。
-2. 下载3.x版本cocos2dx命名成cocos2d放在Example根目录。cocos2dx源码需要改动一处地方才能通过编译，打开2d/CCLabel.h，大约在672行，为updateBMFontScale函数打上virtual修饰符。即
+1. Download using GitHub Clone or directly from `FairyGUI-cocos2dx`.
+2. Download the 3.x version of cocos2dx and name it cocos2d in the Example root directory. Cocos2dx source code needs to be changed in one place to compile, open `2d/CCLabel.h`, about 672 lines, and put the virtual modifier on the `updateBMFontScale` function. which is:
 
   ```
     virtual void updateBMFontScale();
   ```
 
-3. 使用Visual Studio打开Examples/proj.win32/Examples.sln，然后直接运行Demo。
-4. Demo的UI工程在Examples/UIProject下。结合UI工程和例子代码可以了解到FairyGUI在Cocos2dx下的使用方法。
+3. Open `Examples/proj.win32/Examples.sln` using Visual Studio and run the Demo directly.
+4. Demo's UI project is under `Examples/UIProject`. Combine UI engineering and example code to understand how FairyGUI is used under Cocos2dx.
 
-## 加入FairyGUI到你的项目
+## Adding FairyGUI to Your Project
 
-将libfairygui加入到你的WorkSpace里，然后添加引用即可。libfairygui是一个静态库，最后链接到你的程序里。
+Add `libfairygui` to your WorkSpace and add a reference. `Libfairygui` is a static library that is linked to your program.
 
-## 关于GRoot
+## About GRoot
 
-GRoot是UI的根对象，我们可以像Demo那样，每个场景都创建一个GRoot对象。GRoot::getInstance()（或者简单的使用UIRoot这个宏）指向的是最后创建的GRoot对象，一般来说就是当前Scene包含的GRoot对象。Cocos2dx在切换Scene时Scene里的一切东西都会销毁，也包括加入到Scene里的GRoot。如果你想避免界面的重复创建，一个GRoot在不同Scene里公用，那么可以自己对GRoot retain。切换场景后自行add GRoot到Scene即可。
+`GRoot` is the root object of the UI. We can create a `GRoot` object for each scene like in the Demo. `GRoot::getInstance()` (or simply use the `UIRoot` macro) points to the last created `GRoot` object, which is generally the `GRoot` object contained in the current Scene. Cocos2dx will destroy everything in Scene when switching Scene, including `GRoot` added to Scene. If you want to avoid repeated creation of the interface, by using a shared `GRoot` in different Scenes, then you can own `GRoot` retain. After switching the scene, you can add `GRoot` to Scene.
 
-## 事件机制
+## Event System
 
-与事件相关的API有
+The event API has these methods:
 
 ```csharp
     void addEventListener(int eventType, const EventCallback& callback);
@@ -36,9 +36,10 @@ GRoot是UI的根对象，我们可以像Demo那样，每个场景都创建一个
     void removeEventListeners();
 ```
 
-`eventType` 一个事件类型常量，定义在event/UIEventType.h里。
-`callback` 回调函数，可以用CC_CALLBACK_1宏来定义，也可以用Lambda表达式。
-`tag` 如果事件注册后要进行remove操作，那么add的时候必须标识这个事件。这里的机制是调用者提供一个EventTag。EventTag可以用整形，或者一个指针地址来构造，例如可以直接传递this。特别地，0表示没有EventTag，也就是不要使用0作为特殊的EventTag。
+`eventType` An event type constant, defined in `event/UIEventType.h`.
+`callback` The callback function can be defined with the `CC_CALLBACK_1` macro or with a Lambda expression.
+`tag` If the event is to be removed after the event is registered, then this must be added to identify the event. The mechanism here is that the caller provides an `EventTag`. `EventTag` can be constructed with an integer, or a pointer address, for example, you can pass this directly. In particular, 0 means no `EventTag`; meaning, don't use 0 as a special `EventTag`.
 
 ## Lua Binding
-FairyGUI-cocos2dx只提供了C++版本，Lua Binding需要由你自行完成。网上有很多方案可以完成这点。例如这位热心网友的分享：[https://www.jianshu.com/p/547e584e05d8](https://www.jianshu.com/p/547e584e05d8 "FairyGUI在Cocos2d-x下的多平台接入和lua绑定")
+
+FairyGUI-cocos2dx is only available in C++, and Lua Binding needs to be done by you. There are many ways to do this online. For example, the sharing of this enthusiastic netizen:[https://www.jianshu.com/p/547e584e05d8](https://www.jianshu.com/p/547e584e05d8 "FairyGUI在Cocos2d-x下的多平台接入和lua绑定")

--- a/src/guide/sdk/creator.md
+++ b/src/guide/sdk/creator.md
@@ -4,94 +4,94 @@ type: guide_sdk
 order: 4
 ---
 
-## 运行Demo
+## Run Demo
 
-1. 从GitHub Clone或者从[官网产品页](../../product/index.html#CocosCreator SDK)上直接下载FairyGUI-cocoscreator的例子。
-2. SDK基于Cocos Creator 2.x版本，1.x版本不支持，所以请使用2.0以上版本的Creator，推荐使用2.0.7或以上。
-3. 用Cocos Creator打开下载后的例子工程。
-4. 直接运行可以看到效果。
-5. UI界面的工程在UIProject目录，需要使用FairyGUI编辑器打开查看和修改。这部分文件是独立于Creator的，不需要放到Creator的assets目录下。
-6. 例子是使用TS编写的，但核心库是fairygui.js，所以用JS开发不会有任何问题。
-7. fairygui.js未经压缩，发布时cocos会自行压缩，最后的大小会在300K左右。
+1. Download the `FairyGUI-cocoscreator` example directly from GitHub Clone or from the [Official Product Page](../../product/index.html#CocosCreatorSDK).
+2. The SDK is based on Cocos Creator version 2.x. Version 1.x isn't supported, so please use version 2.0 or higher of Creator. It's recommended to use 2.0.7 or above.
+3. Open the example Cocos Creator project.
+4. Run it to see it in action.
+5. The UI interface works in the UIProject directory and needs to be opened for viewing and modification using the FairyGUI editor. This part of the file is independent of Creator and doesn't need to be placed in the `Assets` directory of Creator.
+6. The example is written in TS, but the core library is fairygui.js, so there's no problem with using JS development.
+7. `fairygui.js` is uncompressed. Cocos will compress it itself for release. The final size will be around 300K.
 
-## 加载UI包
+## Load UI Package
 
-FairyGUI是以包为单位组织UI界面的。一个UI包可能包括一个或多个界面。每个UI包发布后将得到一个bin文件后缀的描述文件，和一个或多个图片作为纹理集。这些文件需要放到resources目录，以便动态加载。因为为了避免复杂的依赖的关系，以后由此带来管理的困难。我们的界面不会直接由场景里的东西引用。一个UI包可以随时加载和卸载。
+FairyGUI organizes the UI interface in units of packages. A UI package may include one or more interfaces. After each UI package is released, it will get a description file with a `bin` suffix and one or more pictures as the texture set. These files need to be placed in the resources directory for dynamic loading. In order to avoid complicated dependency relationships, and to avoid management difficulties in the future, our interface isn't directly referenced by things in the scene. A UI package can be loaded and unloaded at any time.
 
-在FairyGUI编辑器直接发布包到Creator的assets/resources目录或者其子目录下。
+Publish the package directly to the `Assets/Resources` directory of Creator or its subdirectories in the FairyGUI editor.
 
 ![](../../images/20181214102714.png)
 
-注意，图片设置为RAW格式即可，不需要设置为Sprite。因为FairyGUI会自己分析Sprite。
+Note that the picture is set to RAW format and doesn't need to be set to Sprite. Because FairyGUI will analyze the Sprite itself.
 
-代码里载入包有两种方式。一种是你负责把文件加载，第二种是让FairyGUI自己去加载。第一种方式是方便你做一个混杂了其它资源的总体的加载，或者显示进度的需求等。
+There are two ways to load a package in your code. One is that you are responsible for loading the file, and the second is for FairyGUI to load it yourself. The first way is to make it easy for you to do a general loading of other resources, or to show the progress (like a loading bar).
 
-第一种方式：
+First method:
 
 ```csharp
-    //这里填写的是相对于resources里的路径
-    let res = [ 
-        "UI/Bag",  //描述文件
-        "UI/Bag_atlas0" //纹理集
+    // Here we are using relative resource paths
+    let res = [
+        "UI/Bag",  //Description file
+        "UI/Bag_atlas0" //Texture set
     ];
     cc.loader.loadResArray(res, function(err, assets) {
-        //都加载完毕后再调用addPackage
-        fgui.UIPackage.addPackage("UI/Bag"); 
+        // Call addPackage after loading
+        fgui.UIPackage.addPackage("UI/Bag");
 
-        //下面就可以开始创建包里的界面了。
+        // Now you can start creating the interface in the package.
     });
 ```
 
-第二种方式：
+Second method:
 ```csharp
-    //这里填写的是相对于resources里的路径
+    // Here we are using a relative resource path
     fgui.UIPackage.loadPackage("UI/Bag", function(err) {
-        //这里不需要再调用addPackage了，直接可以开始创建界面了
+        // There is no need to call addPackage here, you can start creating the interface directly.
     });
 ```
-## 卸载UI包
+## Uninstall UI Package
 
-当一个包不再使用时，可以将其卸载。
+When a package is no longer in use, it can be uninstalled.
 
 ```csharp
-    //这里可以使用包的id，包的名称，包的路径，均可以
+    // Here you can use the package id, the package name, or the package path
     fgui.UIPackage.removePackage("Bag");
 ```
 
-包卸载后，所有包里包含的贴图等资源均会被卸载，由包里创建出来的组件也无法显示正常（虽然不会报错），所以这些组件应该（或已经）被销毁。
-一般不建议包进行频繁装载卸载，因为每次装载卸载必然是要消耗CPU时间（意味着耗电）和产生大量GC的。UI系统占用的内存是可以精确估算的，你可以按照包的使用频率设定哪些包是常驻内存的（建议尽量多）。
+After the package is uninstalled, all the resources contained in the package will be unloaded, and the components created by the package will not be displayed properly (although no error will be reported), so these components should be (or should have been) destroyed.
+It's generally not recommended that the package be loaded and unloaded frequently, because each loading/unloading necessarily consumes CPU time (meaning power consumption) and generates a large amount of GC. The memory occupied by the UI system can be accurately estimated. You can set which packets are in memory according to the frequency of use of the package (recommended as much as possible).
 
-## 创建GRoot
+## Create GRoot
 
-每个场景都需要有一个GRoot，这是UI的根节点。场景载入后，需要手动创建GRoot。
+Each scene needs to have a `GRoot`, which is the root node of the UI. After the scene is loaded, you need to manually create a `GRoot`.
 
 ```csharp
     fgui.GRoot.create();
 ```
 
-## 创建UI
+## Create UI
 
 ```csharp
     let view:fgui.GComponent = fgui.UIPackage.createObject(“包名”, “组件名”).asCom;
-    
-    //以下几种方式都可以将view显示出来：
-    
-    //1，直接加到GRoot显示出来
+
+    // The following methods can display the view:
+
+    // 1，Display by directly adding to GRoot
     fgui.GRoot.inst.addChild(view);
-    
-    //2，使用窗口方式显示
+
+    // 2，Display using a Window
     aWindow.contentPane = view;
     aWindow.show();
-    
-    //3，加到其他组件里
+
+    // 3，Adding to another component
     aComponnent.addChild(view);
 ```
 
-如果界面内容过多，创建时可能引起卡顿，FairyGUI提供了异步创建UI的方式，异步创建方式下，每帧消耗的CPU资源将受到控制，但创建时间也会比同步创建稍久一点。例如：
+If there's too much interface content, it may lag when it's created. FairyGUI provides a way to create a UI asynchronously. In the asynchronous creation mode, the CPU resources consumed per frame will be controlled, but the creation time will be slightly longer than the synchronization creation. E.g:
 
 ```csharp
     let handler = new AsyncOperation();
-    
+
     fgui.UIPackage.createObjectAsync("包名","组件名", myCreateObjectCallback);
 
     void myCreateObjectCallback(obj:fgui.Gobject)
@@ -99,119 +99,119 @@ FairyGUI是以包为单位组织UI界面的。一个UI包可能包括一个或�
     }
 ```
 
-关闭界面一般用隐藏即可，即：
+Closing/hiding the interface:
 
 ```csharp
-    //如果是加在GRoot或者其他父节点的
+    // If the texture set is added to GRoot or other parent nodes...
     view.removeFromParent();
 
-    //如果是窗口
+    // If it's a window
     view.hide();
 ```
 
-如果界面不再使用了，可以销毁它：
+If the interface is no longer used, you can destroy it:
 
 ```csharp
     view.Dispose();
 ```
 
-场景切换时，所有界面都会被销毁。如果不想被销毁，需要创建出界面后，把根节点设置为常驻，并且切换场景前，确保关闭界面。
+When the scene is switched, all interfaces will be destroyed. If you don't want them to be destroyed, you need to create the interface, set the root node as parent, and ensure that the interface is closed before switching the scene.
 
 ```csharp
     cc.game.addPersistNode(view.node);
 ```
 
-## 坐标系统
+## Coordinate System
 
-GObject里的x/y/position值都是**局部坐标**，也就是相对于父元件的偏移。GObject没有提供直接的属性获得对象的全局坐标，但提供了方法进行转换。
+The x/y/position values in `GObject` are all **local coordinates**, which is the offset from the parent. `GObject` doesn't provide a direct property to get the global coordinates of the object, but provides a way to do the conversion.
 
-如果要获得任意一个UI元件在屏幕上的坐标，可以用：
+If you want to get the coordinates of any UI component on the screen, you can use:
 
 ```csharp
     let screenPos:cc.Vec2 = aObject.localToGlobal(cc.Vec2.ZERO);
 ```
 
-（注意，这里说的屏幕，是指FairyGUI语义中的屏幕，是以屏幕左上角为原点的，不是指Creator语义中的屏幕）
+**(Note that the screen mentioned here refers to the screen in the semantics of FairyGUI, which is based on the upper left corner of the screen, NOT the screen in Creator's semantics)**
 
-相反，如果要获取屏幕坐标在UI元件上的局部坐标，可以用：
+Conversely, if you want to get the local coordinates of the screen coordinates on the UI component, you can use:
 
 ```csharp
     let localPos:cc.Vec2 = aObject.globalToLocal(screenPos);
 ```
 
-## 事件系统
+## Event System
 
-FairyGUI直接使用了Creator的事件系统，所以GObject.on/off其实是通过GObject.node.on/off实现的，也就是可以通过GObject.node进行任何事件的操作，包括自定义的事件。在事件回调中，cc.Event中的currentTarget反映的是这个事件是由哪个node派发的，如果要获得这个node对应哪个GObject，可以用这样的方法：
+FairyGUI directly uses Creator's event system, so `GObject.on`/`GObject.off` is actually implemented by GObject.node.on/off, that is, any event can be performed through `GObject.node`, including custom events. In the event callback, the currentTarget in `cc.Event` reflects which node the event was dispatched from. If you want to get the `GObject` corresponding to this node, you can use this method:
 
 ```
     aObject.on(someEventName, this.onHandle, this);
 
     onHandle(evt:cc.Event) {
-        cc.log(evt.currentTarget); //node对象
-        cc.log(fgui.GObject.cast(evt.currentTarget)); //gobject对象
+        cc.log(evt.currentTarget); //Node object
+        cc.log(fgui.GObject.cast(evt.currentTarget)); //GObject object
     }
 ```
 
-## 鼠标/触摸类事件
+## Mouse/Touch Event
 
-对于鼠标事件和触摸事件，FairyGUI里都使用自定义的事件，常量定义在fgui.Event里，这和Creator自身的cc.Node.EventType.TOUCH_BEGIN是不一样的，要注意区别。因为Creator自己的触摸逻辑很难处理穿透/不穿透，以及自定义区域点击这些情况。
+For mouse events and touch events, FairyGUI uses custom events. The constants are defined in fgui.Event. This isn't the same as Creator's own `cc.Node.EventType.TOUCH_BEGIN`. Pay attention to the difference. Because Creator's own touch logic is difficult to handle penetration/non-penetration, as well as custom area clicks.
 
-鼠标/触摸事件回调函数有一个参数：evt:fgui.Event，fgui.Event继承于cc.Event。
+The mouse/touch event callback function has one parameter: `evt:fgui.Event`, and `fgui.Event` inherits from `cc.Event`.
 
-- `TOUCH_BEGIN` 鼠标按键按下（左、中、右键），或者手指按下。鼠标按钮可以从evt.button获得，0-左键,1-中键,2-右键。如果是触摸事件，可以从evt.touchId获得手指ID；如果是鼠标事件，evt.touchId恒定为0。
+- `TOUCH_BEGIN` Fires when a mouse button (left, center, right) is clicked, or a touch is started. The mouse button can be obtained from evt.button, 0-left button, 1-center button, 2-right button. If it's a touch event, you can get the finger ID from `evt.touchId`; if it's a mouse event, `evt.touchId` is always 0.
 
-- `TOUCH_MOVE` 鼠标指针移动或者手指在屏幕上移动。这个事件只有两种情况会触发，1、在TOUCH_BEGIN里调用了evt.captureTouch()，那么后续的移动事件都会在这个对象上触发（无论手指或指针位置是不是在该对象上方）。2、GRoot上的TOUCH_MOVE始终会触发，不需要使用captureTouch捕获。
+- `TOUCH_MOVE` Fires when the mouse pointer, or a finger, is moved across the screen. There are only two situations in this event that can be triggered. 1. When `evt.captureTouch()` is called in `TOUCH_BEGIN`, subsequent move events will be fired on this object (regardless of whether the finger or pointer position is above the object). 2. `TOUCH_MOVE` on `GRoot` will always trigger, no need to use `captureTouch` capture.
 
-- `TOUCH_END` 鼠标按键释放或者手指从屏幕上离开。如果鼠标或者触摸位置已经不在GObject范围内了，那么组件的TouchEnd事件是不会触发的，如果确实需要，可以在TOUCH_BEGIN里调用evt.captureTouch()请求捕获。
+- `TOUCH_END` Fires when the mouse button is released, or when a finger is removed from the screen. If the mouse or touch location is no longer in the `GObject` scope, the component's `TouchEnd` event will not be triggered. If it's needed, it can be called by calling `evt.captureTouch()` in `TOUCH_BEGIN`.
 
-- `CLICK` 点击事件。可以从evt.isDoubleClick判断是单击还是双击。侦听点击事件有个快捷方式：GObject.onClick(callback,...)，比GObject.on(fgui.Event.CLICK,...)简洁点。
+- `CLICK` Click on the event. It can be determined from `evt.isDoubleClick` whether to click or double click. There is a shortcut to listen for click events: `GObject.onClick(callback,...)`, which is more concise than `GObject.on(fgui.Event.CLICK,...)`.
 
-- `ROLL_OVER` 鼠标指针或者手指移入显示对象区域时触发。
+- `ROLL_OVER` Fires when the mouse pointer or finger moves into the display object area.
 
-- `ROLL_OUT` 鼠标指针或者手指移出显示对象区域时触发。
+- `ROLL_OUT` Fires when the mouse pointer or finger moves out of the display object area.
 
-- `MOUSE_WHEEL` 鼠标滚动事件。
+- `MOUSE_WHEEL` Fires when the mouse is scrolled.
 
-如果不在事件回调流程中，需要获得当前鼠标或者手指的位置，可以用：
+If you're not in the event callback function and need to get the current mouse or finger position, you can use:
 
 ```csharp
-    //touchId是手指id，如果你不关心这个，不传入即可
+    // touchId is the finger id. If you don't care about this, don't pass it.
     let pos1:cc.Vec2 = fgui.GRoot.inst.getTouchPosition(touchId);
 ```
 
-在任何时候，如果需要获得当前点击的对象，或者鼠标下的对象，都可以通过以下的方式获得：
+At any time, if you need to get the object you're currently clicking, or the object under the mouse, you can get it in the following way:
 
 ```csharp
     let obj:fgui.GObject = fgui.GRoot.inst.touchTarget;
 
-    //判断是不是在某个组件内
+    // Determine if it's inside a component
     cc.Log(testComponent.isAncestorOf(obj));
 ```
 
-## 字体
+## Font
 
-如果要使用ttf字体，需要这些步骤：
+These steps are required if you want to use TTF fonts:
 
-1、首先需要得到cc.Font对象，这个对象你是从loadRes获得，还是直接在场景中通过脚本的变量获得，可按照项目需求。
+1、First you need to get the cc.Font object, which is obtained from loadRes, or directly obtained from the script in the scene, according to the project requirements.
 
-2、使用fgui.UIConfig.registerFont给这个cc.Font注册一个FairyGUI里使用的字体名称，假定aFont就是cc.Font对象：
+2、Use fgui.UIConfig.registerFont to register the cc.Font with the font name used in FairyGUI, assuming that `aFont` is the cc.Font object:
 
 ```csharp
     fgui.UIConfig.registerFont('myfont', aFont);
 ```
 
-3、如果这个是全局字体：
+3、If it's a global font:
 
 ```csharp
     fgui.UIConfig.defaultFont = 'myFont';
 ```
 
-4、如果这个是某个文字单独指定的字体，例如：
+4、If this is a font specified separately for a text, for example:
 
 ![](../../images/2016-07-06_143622.png)
 
-这里用到了"黑体"这个名字的字体，这是与UIConfig.defaultFont不同的字体，那么我们需要注册这种字体。即：
+Here we use a font named "Black Body", which is a different font from UIConfig.defaultFont. We need to register this font, which looks like:
 
 ```csharp
-    fgui.UIConfig.registerFont('黑体', aFont);
+    fgui.UIConfig.registerFont('Black Body', aFont);
 ```


### PR DESCRIPTION
Translated a good amount to English, by:

1. Using Google Translate to start.

2. Rewriting things to make more sense in English, cutting down on verbosity where possible, using English conjunctions, simple possessives ("Y's X" instead of "X of the Y").

3. Looking in the FairyGUI editor to ensure that the names of translated things match the actual English UI that already exists.

4. Changed code comments and code examples (like filenames) to English equivalents (instead of leaving them Chinese characters).

5. Added additional formatting for `tags`, and specific library components like `GRoot` (etc).

6. Changed cultural things like "Droid Sans Fallback" (which AFAIK, doesn't exist on English devices) to "Roboto" (which is the new default on English devices post Android 4.0).
